### PR TITLE
Use <source> element to setup media instead the video.src attribute

### DIFF
--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -79,10 +79,20 @@ export default class HTML5TVsPlayback extends Playback {
   }
 
   _setupSource(sourceURL) {
-    if (this.el.src === sourceURL) return
+    const currentSource = this.$sourceElement && this.$sourceElement.src
+    if (sourceURL === currentSource) return
 
-    this.el.src = sourceURL
-    this._src = this.el.src
+    this._setSourceOnVideoTag(sourceURL)
+  }
+
+  _setSourceOnVideoTag(sourceURL) {
+    this.$sourceElement = document.createElement('source')
+    this.$sourceElement.type = MIME_TYPES_BY_EXTENSION[getExtension(sourceURL)]
+    this.$sourceElement.src = sourceURL
+
+    this._src = this.$sourceElement.src
+
+    this.el.appendChild(this.$sourceElement)
   }
 
   _onCanPlay(e) {

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -422,22 +422,55 @@ describe('HTML5TVsPlayback', function() {
 
   describe('_setupSource method', () => {
     test('avoids unnecessary video.src updates', () => {
-      this.playback.el.src = URL_VIDEO_MP4_EXAMPLE
+      jest.spyOn(this.playback, '_setSourceOnVideoTag')
+
+      this.playback.$sourceElement = document.createElement('source')
+      this.playback.$sourceElement.src = URL_VIDEO_MP4_EXAMPLE
+      this.playback.el.appendChild(this.playback.$sourceElement)
       this.playback._setupSource(URL_VIDEO_MP4_EXAMPLE)
 
-      expect(this._src).toBeUndefined()
+      expect(this.playback._setSourceOnVideoTag).not.toHaveBeenCalled()
     })
 
-    test('sets received source URL as video.src attribute', () => {
+    test('calls _setSourceOnVideoTag method', () => {
+      jest.spyOn(this.playback, '_setSourceOnVideoTag')
       this.playback._setupSource(URL_VIDEO_MP4_EXAMPLE)
 
-      expect(this.playback.el.src).toEqual(URL_VIDEO_MP4_EXAMPLE)
+      expect(this.playback._setSourceOnVideoTag).toHaveBeenCalledWith(URL_VIDEO_MP4_EXAMPLE)
+    })
+  })
+
+  describe('_setSourceOnVideoTag method', () => {
+    test('creates the $sourceElement reference', () => {
+      expect(this.playback.$sourceElement).toBeUndefined()
+
+      this.playback._setSourceOnVideoTag(URL_VIDEO_MP4_EXAMPLE)
+
+      expect(this.playback.$sourceElement).toBeDefined()
     })
 
-    test('saves current video.src value on internal reference', () => {
+    test('sets received source URL extension as $sourceElement.type attribute', () => {
+      this.playback._setSourceOnVideoTag(URL_VIDEO_MP4_EXAMPLE)
+
+      expect(this.playback.$sourceElement.type).toEqual('video/mp4')
+    })
+
+    test('sets received source URL as $sourceElement.src attribute', () => {
+      this.playback._setSourceOnVideoTag(URL_VIDEO_MP4_EXAMPLE)
+
+      expect(this.playback.$sourceElement.src).toEqual(URL_VIDEO_MP4_EXAMPLE)
+    })
+
+    test('saves current $sourceElement.src value on internal reference', () => {
       this.playback._setupSource(URL_VIDEO_MP4_EXAMPLE)
 
       expect(this.playback._src).toEqual(URL_VIDEO_MP4_EXAMPLE)
+    })
+
+    test('appends $sourceElement into the playback.el', () => {
+      this.playback._setSourceOnVideoTag(URL_VIDEO_MP4_EXAMPLE)
+
+      expect(this.playback.el.firstChild).toEqual(this.playback.$sourceElement)
     })
   })
 


### PR DESCRIPTION
## Summary 

**DISCLAIMER: To merge this PR, is mandatory the previous merge of the #1**

Currently, the way that the playback implementation setup one media is just setting the attribute `src` on the `<video>` element. This approach works well until now but when we trying to play other media with specific features (like DRM) the video element never loads as expected.

Apparently, only with the use of an `<source>` element with the `<video>` element one media with DRM plays without errors. Because that, this PR applies this new mode to set up one media. This approach works with other formats that already supported too.

## Changes

- Create new method `_setSourceOnVideoTag` with the responsibility to:
  - Create the `<source>` element;
  - Save internal reference of the `<source>` element (`$sourceElement`);
  - Append the `<source>` element into the `video` element;
  - Save internal reference of the current media URL;
 - Refactor `_setupSource` method to call `_setSourceOnVideoTag` with the received source URL;

## How to test

- Play any supported source;
- Check for the `<video>` element on the DOM tree;
  - The `<video>` element should have the `<source>` element as a child;
  -  the media should be play as expected;


## A picture/video tells a thousand words

### Before this PR
![Screen Shot 2021-06-30 at 15 36 00](https://user-images.githubusercontent.com/5631063/124013700-0621fd00-d9b9-11eb-9211-56397e2467d9.png)

### After this PR
![Screen Shot 2021-06-30 at 15 34 28](https://user-images.githubusercontent.com/5631063/124013675-fc989500-d9b8-11eb-9e30-0d7681f84698.png)