### PR TITLE
Adds support for DRM content with Playready

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,28 @@ A Clappr HTML5 playback for smart TVs devices that implement the [HbbTV 2.0.1 sp
 * Supports VoD;
   * Current mime types: [`video/mp4`, `application/vnd.apple.mpegurl`, `application/vnd.ms-sstr+xml`].
 * Supports DRM content;
-  * Using [`oipfDrmAgent`](https://www.oipf.tv/docs/OIPF-T1-R2_Specification-Volume-5-Declarative-Application-Environment-v2_3-2014-01-24.pdf#page=121) and only with Playready at the moment.
+  * Using [`oipfDrmAgent`](https://www.oipf.tv/docs/OIPF-T1-R2_Specification-Volume-5-Declarative-Application-Environment-v2_3-2014-01-24.pdf#page=121). (Only with Playready at the moment)
 
 ## Configuration
+The options for the playback must be placed in the `html5TvsPlayback` property as shown below:
+
 ```javascript
 var player = new Clappr.Player({
   source: 'http://your.video/here.mp4',
-  plugins: [HTML5TVsPlayback]
+  plugins: [HTML5TVsPlayback],
+  html5TvsPlayback: {
+    drm: {
+      licenseServerURL: 'https://my-license-server.com/keys/my-key',
+    },
+  },
 });
 ```
+
+### `drm {Object}`
+Group all DRM-related config. The currently available configs are:
+
+* #### `licenseServerURL {String}`
+  The license server URL used on the license acquisition. This config is mandatory to play content with DRM.
 
 ## API Documentation
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A Clappr HTML5 playback for smart TVs devices that implement the [HbbTV 2.0.1 sp
 ## Features
 * Supports VoD;
   * Current mime types: [`video/mp4`, `application/vnd.apple.mpegurl`, `application/vnd.ms-sstr+xml`].
+* Supports DRM content;
+  * Using [`oipfDrmAgent`](https://www.oipf.tv/docs/OIPF-T1-R2_Specification-Volume-5-Declarative-Application-Environment-v2_3-2014-01-24.pdf#page=121) and only with Playready at the moment.
 
 ## Configuration
 ```javascript

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ var player = new Clappr.Player({
 | `playback.buffering` | Indicates whether the media on the buffering state. | `{Boolean}` |
 
 ## Next Steps
-- [ ] Media with DRM;
+- [x] Media with DRM;
 - [ ] Live media;
 - [ ] subtitles/closed captions;
 - [ ] multi-audio;

--- a/src/drm/drm_handler.js
+++ b/src/drm/drm_handler.js
@@ -1,0 +1,128 @@
+import { Log } from '@clappr/core'
+
+const MESSAGE_TYPE = 'application/vnd.ms-playready.initiator+xml'
+const DRM_SYSTEM_ID = 'urn:dvb:casystemid:19219'
+
+export const getLicenseOverrideMessageTemplate = licenseServerURL => {
+  const template = '<?xml version="1.0" encoding="utf-8"?>'
+  + '<PlayReadyInitiator xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols/">'
+  + '<LicenseServerUriOverride>'
+  + `<LA_URL>${licenseServerURL}</LA_URL>`
+  + '</LicenseServerUriOverride>'
+  + '</PlayReadyInitiator>'
+  return template
+}
+
+export const getClearMessageTemplate = () => {
+  const template = '<?xml version="1.0" encoding="utf-8"?>'
+  + '<PlayReadyInitiator xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols/">'
+  + '</PlayReadyInitiator>'
+  return template
+}
+
+export const createDrmAgent = () => {
+  const drmElement = document.createElement('object')
+
+  drmElement.id = 'oipfdrmagent'
+  drmElement.type = 'application/oipfdrmagent'
+  drmElement.style.visibility = 'hidden'
+  drmElement.style.position = 'absolute'
+  drmElement.style.top = '0'
+  drmElement.style.left = '0'
+  drmElement.style.width = '0'
+  drmElement.style.height = '0'
+
+  return drmElement
+}
+
+/* eslint-disable-next-line func-style */
+export function sendLicenseRequest(config = {}, callback = () => {}) {
+  const successCallback = callback.bind(this)
+  let oipfdrmagent = document.getElementById('oipfdrmagent')
+
+  if (!oipfdrmagent) {
+    oipfdrmagent = createDrmAgent()
+    this && this.el
+      ? this.el.appendChild(oipfdrmagent)
+      : document.body.appendChild(oipfdrmagent)
+  }
+
+  !config.licenseServerURL
+    && Log.warn('DRMHandler', 'No one license server is found. The expected result for this behavior is clear the current license.')
+  const xmlLicenceAcquisition = getLicenseOverrideMessageTemplate(config.licenseServerURL)
+
+  const drmRightsErrorHandler = resultCode => {
+    const errorMessage = {
+      0: 'DRM: No license error',
+      1: 'DRM: Invalid license error',
+      2: 'license valid',
+    }
+
+    if (resultCode < 2) {
+      Log.error('DRMHandler', 'Error at onDRMRightsError call', errorMessage[resultCode])
+      return errorMessage[resultCode]
+    }
+  }
+
+  const drmMessageResultHandler = (messageID, resultMessage, resultCode) => {
+    Log.info('DRMHandler', 'onDRMMessageResult messageID', messageID)
+    Log.info('DRMHandler', 'onDRMMessageResult resultMessage', resultMessage)
+    Log.info('DRMHandler', 'onDRMMessageResult resultCode', resultCode)
+
+    const errorMessage = {
+      1: 'DRM: Unspecified error',
+      2: 'DRM: Cannot process request',
+      3: 'DRM: Wrong format',
+      4: 'DRM: User Consent Needed',
+      5: 'DRM: Unknown DRM system',
+    }
+
+    if (resultCode > 0) {
+      Log.error('DRMHandler', 'Error at onDRMMessageResult call', errorMessage[resultCode])
+      return errorMessage[resultCode]
+    }
+
+    successCallback()
+  }
+
+  try {
+    oipfdrmagent.onDRMRightsError = drmRightsErrorHandler
+    oipfdrmagent.onDRMMessageResult = drmMessageResultHandler
+    oipfdrmagent.sendDRMMessage(MESSAGE_TYPE, xmlLicenceAcquisition, DRM_SYSTEM_ID)
+  } catch (error) {
+    Log.error('DRMHandler', 'Error at sendDRMMessage call', error.message)
+  }
+}
+
+/* eslint-disable-next-line func-style */
+export function clearLicenseRequest(callback = () => {}) {
+  const successCallback = callback.bind(this)
+  const oipfdrmagent = document.getElementById('oipfdrmagent')
+
+  if (!oipfdrmagent) {
+    Log.warn('DRMHandler', 'No one DRM license has been configured before. It\'s not necessary to clear any license server.')
+    return
+  }
+
+  const xmlLicenceAcquisition = getClearMessageTemplate()
+
+  try {
+    oipfdrmagent.onDRMRightsError = successCallback
+
+    oipfdrmagent.onDRMMessageResult = () => {
+      oipfdrmagent.remove()
+      successCallback()
+    }
+
+    oipfdrmagent.sendDRMMessage(MESSAGE_TYPE, xmlLicenceAcquisition, DRM_SYSTEM_ID)
+  } catch (error) {
+    Log.error('DRMHandler', 'Error at sendDRMMessage call', error.message)
+  }
+}
+
+const DRMHandler = {
+  sendLicenseRequest,
+  clearLicenseRequest,
+}
+
+export default DRMHandler

--- a/src/drm/drm_handler.js
+++ b/src/drm/drm_handler.js
@@ -36,8 +36,9 @@ export const createDrmAgent = () => {
 }
 
 /* eslint-disable-next-line func-style */
-export function sendLicenseRequest(config = {}, callback = () => {}) {
-  const successCallback = callback.bind(this)
+export function sendLicenseRequest(config = {}, onSuccess = () => {}, onFail = () => {}) {
+  const successCallback = onSuccess.bind(this)
+  const errorCallback = onFail.bind(this)
   let oipfdrmagent = document.getElementById('oipfdrmagent')
 
   if (!oipfdrmagent) {
@@ -55,12 +56,12 @@ export function sendLicenseRequest(config = {}, callback = () => {}) {
     const errorMessage = {
       0: 'DRM: No license error',
       1: 'DRM: Invalid license error',
-      2: 'license valid',
+      2: 'DRM: License valid',
     }
 
     if (resultCode < 2) {
       Log.error('DRMHandler', 'Error at onDRMRightsError call', errorMessage[resultCode])
-      return errorMessage[resultCode]
+      errorCallback(errorMessage[resultCode])
     }
   }
 
@@ -79,7 +80,7 @@ export function sendLicenseRequest(config = {}, callback = () => {}) {
 
     if (resultCode > 0) {
       Log.error('DRMHandler', 'Error at onDRMMessageResult call', errorMessage[resultCode])
-      return errorMessage[resultCode]
+      errorCallback(errorMessage[resultCode])
     }
 
     successCallback()
@@ -91,12 +92,14 @@ export function sendLicenseRequest(config = {}, callback = () => {}) {
     oipfdrmagent.sendDRMMessage(MESSAGE_TYPE, xmlLicenceAcquisition, DRM_SYSTEM_ID)
   } catch (error) {
     Log.error('DRMHandler', 'Error at sendDRMMessage call', error.message)
+    errorCallback(error.message)
   }
 }
 
 /* eslint-disable-next-line func-style */
-export function clearLicenseRequest(callback = () => {}) {
-  const successCallback = callback.bind(this)
+export function clearLicenseRequest(onSuccess = () => {}, onFail = () => {}) {
+  const successCallback = onSuccess.bind(this)
+  const errorCallback = onFail.bind(this)
   const oipfdrmagent = document.getElementById('oipfdrmagent')
 
   if (!oipfdrmagent) {
@@ -117,6 +120,7 @@ export function clearLicenseRequest(callback = () => {}) {
     oipfdrmagent.sendDRMMessage(MESSAGE_TYPE, xmlLicenceAcquisition, DRM_SYSTEM_ID)
   } catch (error) {
     Log.error('DRMHandler', 'Error at sendDRMMessage call', error.message)
+    errorCallback(error.message)
   }
 }
 

--- a/src/drm/drm_handler.test.js
+++ b/src/drm/drm_handler.test.js
@@ -1,0 +1,244 @@
+import mockConsole from 'jest-mock-console'
+
+import DRMHandler, {
+  getLicenseOverrideMessageTemplate,
+  getClearMessageTemplate,
+  createDrmAgent,
+  sendLicenseRequest,
+  clearLicenseRequest,
+} from './drm_handler'
+
+const LOG_WARN_STYLE = 'color: #ff8000;font-weight: bold; font-size: 13px;'
+const LOG_WARN_HEAD_MESSAGE = '%c[warn][DRMHandler]'
+
+describe('DRMHandler', function() {
+  beforeEach(() => {
+    this.restoreConsole = mockConsole()
+    jest.clearAllMocks()
+  })
+  afterEach(() => this.restoreConsole())
+
+  test('only exports methods to handle with license request', () => {
+    expect(DRMHandler.sendLicenseRequest).toBeDefined()
+    expect(DRMHandler.clearLicenseRequest).toBeDefined()
+    expect(DRMHandler.getLicenseOverrideMessageTemplate).toBeUndefined()
+    expect(DRMHandler.getClearMessageTemplate).toBeUndefined()
+    expect(DRMHandler.createDrmAgent).toBeUndefined()
+  })
+
+  describe('getLicenseOverrideMessageTemplate method', () => {
+    test('returns XML template with received license server URL', () => {
+      const fakeLicenseServerURL = 'http://fake-domain/fake_folder/playready?deviceId=FAKEID'
+      const result = '<?xml version="1.0" encoding="utf-8"?>'
+      + '<PlayReadyInitiator xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols/">'
+      + '<LicenseServerUriOverride>'
+      + `<LA_URL>${fakeLicenseServerURL}</LA_URL>`
+      + '</LicenseServerUriOverride>'
+      + '</PlayReadyInitiator>'
+      const response = getLicenseOverrideMessageTemplate(fakeLicenseServerURL)
+
+      expect(response).toEqual(result)
+    })
+  })
+
+  describe('getClearMessageTemplate method', () => {
+    test('returns XML template without any licenseServerURL', () => {
+      const result = '<?xml version="1.0" encoding="utf-8"?>'
+      + '<PlayReadyInitiator xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols/">'
+      + '</PlayReadyInitiator>'
+
+      expect(getClearMessageTemplate()).toEqual(result)
+    })
+  })
+
+  describe('createDrmAgent method', () => {
+    test('returns a DOM element with a specific type to handle with the DRM license request', () => {
+      const drmElement = createDrmAgent()
+
+      expect(drmElement.tagName).toEqual('OBJECT')
+      expect(drmElement.type).toEqual('application/oipfdrmagent')
+    })
+
+    test('returns a DOM element with properties that avoids showing it on the screen', () => {
+      const drmElement = createDrmAgent()
+
+      expect(drmElement.id).toEqual('oipfdrmagent')
+      expect(drmElement.style.visibility).toEqual('hidden')
+      expect(drmElement.style.position).toEqual('absolute')
+      expect(drmElement.style.top).toEqual('0px')
+      expect(drmElement.style.left).toEqual('0px')
+      expect(drmElement.style.width).toEqual('0px')
+      expect(drmElement.style.height).toEqual('0px')
+    })
+  })
+
+  describe('sendLicenseRequest method', () => {
+    beforeEach(() => {
+      this.config = { licenseServerURL: 'http://fake-domain/fake_folder/playready?deviceId=FAKEID' }
+    })
+    afterEach(() => {
+      const drmAgentElement = document.getElementById('oipfdrmagent')
+      drmAgentElement && drmAgentElement.remove()
+    })
+
+    test('reuses drmAgent element if already exists', () => {
+      const cb = jest.fn()
+
+      document.body.appendChild(createDrmAgent())
+      sendLicenseRequest(this.config, cb)
+
+      const duplicateIds = document.querySelectorAll('[id=\'oipfdrmagent\']')
+
+      expect(duplicateIds.length).toEqual(1)
+    })
+
+    test('prefer to append drmAgent on parent element of received scope if exits', () => {
+      const cb = jest.fn()
+      const wantedScope = { el: document.createElement('div') }
+      sendLicenseRequest.call(wantedScope, this.config, cb)
+
+      expect(wantedScope.el.firstChild.id).toEqual('oipfdrmagent')
+    })
+
+    test('appends drmAgent on document.body if any external scope is received', () => {
+      const cb = jest.fn()
+      sendLicenseRequest(this.config, cb)
+
+      expect(document.body.firstChild.id).toEqual('oipfdrmagent')
+    })
+
+    test('logs warn message if no one licenser server URL is received', () => {
+      sendLicenseRequest()
+
+      /* eslint-disable-next-line no-console */
+      expect(console.log).toHaveBeenNthCalledWith(1,
+        LOG_WARN_HEAD_MESSAGE,
+        LOG_WARN_STYLE,
+        'No one license server is found. The expected result for this behavior is clear the current license.',
+      )
+    })
+
+    test('logs a error message if the sendDRMMessage call fails', () => {
+      const cb = jest.fn()
+      sendLicenseRequest(this.config, cb)
+
+      /* eslint-disable-next-line no-console */
+      expect(console.log).toHaveBeenCalledWith(
+        '%c[error][DRMHandler]',
+        'color: #ff0000;font-weight: bold; font-size: 13px;',
+        'Error at sendDRMMessage call',
+        'oipfdrmagent.sendDRMMessage is not a function',
+      )
+    })
+
+    describe('at onDRMRightsError callback', () => {
+      test('don\'t return one error if the received code number is greater o equal 2', () => {
+        document.body.appendChild(createDrmAgent())
+        const drmAgentElement = document.getElementById('oipfdrmagent')
+        drmAgentElement.sendDRMMessage = () => {}
+
+        const cb = jest.fn()
+        sendLicenseRequest(this.config, cb)
+        const errorResponse = drmAgentElement.onDRMRightsError(2)
+
+        expect(errorResponse).toBeUndefined()
+      })
+
+      test('returns one error if the received code number is below 2', () => {
+        document.body.appendChild(createDrmAgent())
+        const drmAgentElement = document.getElementById('oipfdrmagent')
+        drmAgentElement.sendDRMMessage = () => {}
+
+        const cb = jest.fn()
+        sendLicenseRequest(this.config, cb)
+        const errorResponse = drmAgentElement.onDRMRightsError(1)
+
+        expect(errorResponse).toEqual('DRM: Invalid license error')
+      })
+    })
+
+    describe('at onDRMMessageResult callback', () => {
+      test('returns one error if the received result code is greater than 0', () => {
+        document.body.appendChild(createDrmAgent())
+        const drmAgentElement = document.getElementById('oipfdrmagent')
+        drmAgentElement.sendDRMMessage = () => {}
+
+        const cb = jest.fn()
+        sendLicenseRequest(this.config, cb)
+        const resultResponse = drmAgentElement.onDRMMessageResult(0, 'a error message', 1)
+
+        expect(resultResponse).toEqual('DRM: Unspecified error')
+      })
+
+      test('calls the successCallback if the received result code is 0', () => {
+        document.body.appendChild(createDrmAgent())
+        const drmAgentElement = document.getElementById('oipfdrmagent')
+        drmAgentElement.sendDRMMessage = () => {}
+
+        const cb = jest.fn()
+        sendLicenseRequest(this.config, cb)
+        drmAgentElement.onDRMMessageResult(0, 'a success message', 0)
+
+        expect(cb).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('clearLicenseRequest method', () => {
+    afterEach(() => {
+      const drmAgentElement = document.getElementById('oipfdrmagent')
+      drmAgentElement && drmAgentElement.remove()
+    })
+
+    test('only clear license server if one drmAgent element already exists', () => {
+      clearLicenseRequest()
+
+      /* eslint-disable-next-line no-console */
+      expect(console.log).toHaveBeenCalledWith(
+        LOG_WARN_HEAD_MESSAGE,
+        LOG_WARN_STYLE,
+        'No one DRM license has been configured before. It\'s not necessary to clear any license server.',
+      )
+    })
+
+    test('logs a error message if the sendDRMMessage call fails', () => {
+      const cb = jest.fn()
+      document.body.appendChild(createDrmAgent())
+      clearLicenseRequest(cb)
+
+      /* eslint-disable-next-line no-console */
+      expect(console.log).toHaveBeenCalledWith(
+        '%c[error][DRMHandler]',
+        'color: #ff0000;font-weight: bold; font-size: 13px;',
+        'Error at sendDRMMessage call',
+        'oipfdrmagent.sendDRMMessage is not a function',
+      )
+    })
+
+    describe('at onDRMMessageResult callback', () => {
+      test('removes drmAgentElement from DOM', () => {
+        document.body.appendChild(createDrmAgent())
+        const drmAgentElement = document.getElementById('oipfdrmagent')
+        drmAgentElement.sendDRMMessage = () => {}
+
+        const cb = jest.fn()
+        clearLicenseRequest(cb)
+        drmAgentElement.onDRMMessageResult()
+
+        expect(document.getElementById('oipfdrmagent')).toBeNull()
+      })
+
+      test('calls the successCallback', () => {
+        document.body.appendChild(createDrmAgent())
+        const drmAgentElement = document.getElementById('oipfdrmagent')
+        drmAgentElement.sendDRMMessage = () => {}
+
+        const cb = jest.fn()
+        clearLicenseRequest(cb)
+        drmAgentElement.onDRMMessageResult()
+
+        expect(cb).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -65,6 +65,8 @@ export default class HTML5TVsPlayback extends Playback {
     }
   }
 
+  get config() { return this.options.html5TvsPlayback }
+
   constructor(options, i18n, playerError) {
     super(options, i18n, playerError)
     this._setPrivateFlags()

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -207,6 +207,7 @@ export default class HTML5TVsPlayback extends Playback {
   _onEnded(e) {
     Log.info(this.name, 'The HTMLMediaElement ended event is triggered: ', e)
     this.trigger(Events.PLAYBACK_ENDED, this.name)
+    this._wipeUpMedia()
   }
 
   _onError(e) {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -105,6 +105,11 @@ export default class HTML5TVsPlayback extends Playback {
     this._drmConfigured = true
     this._setSourceOnVideoTag(this.options.src)
   }
+
+  _onDrmCleared() {
+    this._drmConfigured = false
+  }
+
   _onCanPlay(e) {
     Log.info(this.name, 'The HTMLMediaElement canplay event is triggered: ', e)
     if (this._isBuffering) {
@@ -245,21 +250,22 @@ export default class HTML5TVsPlayback extends Playback {
   stop() {
     this.pause()
     this._isStopped = true
-    this._isReady = false
     this._wipeUpMedia()
     this.trigger(Events.PLAYBACK_STOP)
   }
 
   destroy() {
     this._isDestroyed = true
-    this._isReady = false
     super.destroy()
     this._wipeUpMedia()
     this._src = null
   }
 
   _wipeUpMedia() {
-    this.el.removeAttribute('src') // The src attribute will be added again in play().
+    this._isReady = false
+    this._drmConfigured && DRMHandler.clearLicenseRequest.call(this, this._onDrmCleared)
+    this.$sourceElement && this.$sourceElement.removeAttribute('src') // The src attribute will be added again in play().
+    this.$sourceElement && this.$sourceElement.remove()
     this.el.load() // Loads with no src attribute to stop the loading of the previous source and avoid leaks.
   }
 

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -382,6 +382,17 @@ describe('HTML5TVsPlayback', function() {
     })
   })
 
+  test('have a getter called config', () => {
+    expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'config').get).toBeTruthy()
+  })
+
+  test('config getter returns the options.html5TvsPlayback value', () => {
+    const { core, container } = setupTest({ src: URL_VIDEO_MP4_EXAMPLE })
+    core.activeContainer = container
+
+    expect(container.playback.config).toEqual(core.options.html5TvsPlayback)
+  })
+
   describe('constructor', () => {
     test('calls _setPrivateFlags method', () => {
       jest.spyOn(HTML5TVsPlayback.prototype, '_setPrivateFlags')

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -662,6 +662,13 @@ describe('HTML5TVsPlayback', function() {
 
       expect(cb).toHaveBeenCalledTimes(1)
     })
+
+    test('calls _wipeUpMedia method', () => {
+      jest.spyOn(this.playback, '_wipeUpMedia')
+      this.playback._onEnded()
+
+      expect(this.playback._wipeUpMedia).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('_onError callback', () => {


### PR DESCRIPTION
## Summary 

**DISCLAIMER: To merge this PR, is mandatory the previous merge of the #1 and #2.**

Creates a new module to handle with the DRM license acquisition. This module only supports Playready protection at the moment and only implements the `post-acquisition` type of the license acquisitions. More info about license acquisition on [Playready docs](https://docs.microsoft.com/en-us/playready/overview/license-acquisition#proactive-reactive-license-acquisition)

Also, refactor the playback to do the license acquisition before load one media with DRM if the new `html5TvsPlayback.drm.licenseServerURL` config exists and the new flag `_drmConfigured` is `false`.

## Changes

- `src/drm`:
  - Create `drm_handler.js` that export the `DRMHandler` module for request and clear the license server URL;
  - Create `drm_handler.test.js` to cover with tests all the code on the `drm_handler.js` file.
- `html5_playback.js`:
  - Create new option `html5TvsPlayback.drm`;
    - This option is an object, supporting to receive the attribute `licenseServerURL`;
    - The attribute `licenseServerURL` receives one license server URL;
  -  Create `_drmConfigured` flag;
  -  Create `_onDrmConfigured` callback to update `_drmConfigured` flag and call `_setSourceOnVideoTag` method with `options.src`;
  - Create `_onDrmCleared` callback to update `_drmConfigured` flag;
  - Create `_onDrmError` callback to trigger the DRM error on `PLAYBACK_ERROR` event;
  - Refactor `_setupSource` method to do the license acquisition before load one media;
  - refactor `_wipeUpMedia` method to clear the configured license server URL if exists;
  - refactor `_wipeUpMedia` method to clear the `<source>` element;
  - Move the value update of the `_isReady` flag from `stop` and `destroy` methods to the `wipeUpMedia` method;
  - Refactor the `_onEnded` callback to call `wipeUpMedia` method;
- `html5_playback.test.js`:
  - Cover with tests all the code added on the `html5_playback.js` file;

## How to test

- Play one media with DRM;
  - Remember: This code only supports Playready protection.
  - License Server URL sample: `http://test.playready.microsoft.com/service/rightsmanager.asmx?cfg=(persist:false,sl:150)`
  - Protected smoothStreaming sample: `http://profficialsite.origin.mediaservices.windows.net/c51358ea-9a5e-4322-8951-897d640fdfd7/tearsofsteel_4k.ism/manifest`
  - More samples here: `https://testweb.playready.microsoft.com/Content/Content2X`
- Set the license server URL on the `html5TvsPlayback.drm.licenseServerURL` config;
  - `new Clappr.Player({ source: 'media_with_DRM', plugins: [HTML5TVsPlayback], html5TvsPlayback: { drm: { licenseServerURL: 'license_server_url' } } })`
- Play the media;
  - The media should play as expected.