### PR TITLE
Add support to interactive live content (DVR)

### DIFF
--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -46,6 +46,8 @@ export default class HTML5TVsPlayback extends Playback {
 
   get buffering() { return this._isBuffering }
 
+  get isLive() { return this.mediaType === Playback.LIVE }
+
   get config() { return this.options.html5TvsPlayback }
 
   get events() {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -51,8 +51,8 @@ export default class HTML5TVsPlayback extends Playback {
   get isLive() { return this.mediaType === Playback.LIVE }
 
   get minimumDvrSizeConfig() {
-    const DVRSizeConfig = this.options.playback && this.options.playback.minimumDvrSize
-    return typeof DVRSizeConfig !== 'undefined' && typeof DVRSizeConfig === 'number' && DVRSizeConfig
+    const dvrSizeConfig = this.options.playback && this.options.playback.minimumDvrSize
+    return typeof dvrSizeConfig !== 'undefined' && typeof dvrSizeConfig === 'number' && dvrSizeConfig
   }
 
   get dvrSize() { return this.minimumDvrSizeConfig ? this.minimumDvrSizeConfig : DEFAULT_MINIMUM_DVR_SIZE }

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -35,7 +35,12 @@ export default class HTML5TVsPlayback extends Playback {
 
   get currentTime() { return this.el.currentTime }
 
-  get duration() { return this.el.duration }
+  get duration() {
+    // The HTMLMediaElement.duration returns Infinity for live streams: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/duration#value
+    return this.isLive
+      ? this.el.seekable.end(0) - this.el.seekable.start(0)
+      : this.el.duration
+  }
 
   get ended() { return this.el.ended }
 

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -41,6 +41,8 @@ export default class HTML5TVsPlayback extends Playback {
 
   get buffering() { return this._isBuffering }
 
+  get config() { return this.options.html5TvsPlayback }
+
   get events() {
     return {
       canplay: this._onCanPlay,
@@ -67,8 +69,6 @@ export default class HTML5TVsPlayback extends Playback {
       error: this._onError,
     }
   }
-
-  get config() { return this.options.html5TvsPlayback }
 
   constructor(options, i18n, playerError) {
     super(options, i18n, playerError)

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -241,10 +241,6 @@ export default class HTML5TVsPlayback extends Playback {
       : this.trigger(Events.PLAYBACK_ERROR, formattedError)
   }
 
-  getPlaybackType() {
-    return Playback.VOD
-  }
-
   play() {
     this._isStopped = false
     this._setupSource(this._src)
@@ -319,4 +315,11 @@ export default class HTML5TVsPlayback extends Playback {
    * Use the playing getter instead of it.
    */
   isPlaying() { return this.playing }
+
+  /**
+   * @deprecated
+   * This method currently exists for backward compatibility reasons.
+   * Use the mediaType getter instead of it.
+   */
+  getPlaybackType() { return this.mediaType }
 }

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -48,6 +48,11 @@ export default class HTML5TVsPlayback extends Playback {
 
   get isLive() { return this.mediaType === Playback.LIVE }
 
+  get minimumDvrSizeConfig() {
+    const DVRSizeConfig = this.options.playback && this.options.playback.minimumDvrSize
+    return typeof DVRSizeConfig !== 'undefined' && typeof DVRSizeConfig === 'number' && DVRSizeConfig
+  }
+
   get config() { return this.options.html5TvsPlayback }
 
   get events() {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -27,6 +27,8 @@ export default class HTML5TVsPlayback extends Playback {
 
   get tagName() { return 'video' }
 
+  get mediaType() { return this.el.duration === Infinity ? Playback.LIVE : Playback.VOD }
+
   get isReady() { return this.el.readyState >= READY_STATE_STAGES.HAVE_CURRENT_DATA }
 
   get playing() { return !this.el.paused && !this.el.ended }

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -56,6 +56,8 @@ export default class HTML5TVsPlayback extends Playback {
 
   get dvrSize() { return this.minimumDvrSizeConfig ? this.minimumDvrSizeConfig : DEFAULT_MINIMUM_DVR_SIZE }
 
+  get dvrEnabled() { return this.duration >= this.dvrSize && this.isLive }
+
   get config() { return this.options.html5TvsPlayback }
 
   get events() {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -40,7 +40,7 @@ export default class HTML5TVsPlayback extends Playback {
   get duration() {
     // The HTMLMediaElement.duration returns Infinity for live streams: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/duration#value
     return this.isLive
-      ? this.el.seekable.end(0) - this.el.seekable.start(0)
+      ? this.el.seekable.end(this.el.seekable.length - 1) - this.el.seekable.start(0)
       : this.el.duration
   }
 

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -141,6 +141,11 @@ export default class HTML5TVsPlayback extends Playback {
     this.trigger(Events.PLAYBACK_ERROR, formattedError)
   }
 
+  _updateDvr(status) {
+    this.trigger(Events.PLAYBACK_DVR, status)
+    this.trigger(Events.PLAYBACK_STATS_ADD, { dvr: status })
+  }
+
   _onCanPlay(e) {
     Log.info(this.name, 'The HTMLMediaElement canplay event is triggered: ', e)
     if (this._isBuffering) {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -5,6 +5,7 @@ import {
   MIME_TYPES_BY_EXTENSION,
   READY_STATE_STAGES,
   UNKNOWN_ERROR,
+  DEFAULT_MINIMUM_DVR_SIZE,
   getExtension,
 } from './utils/constants'
 
@@ -52,6 +53,8 @@ export default class HTML5TVsPlayback extends Playback {
     const DVRSizeConfig = this.options.playback && this.options.playback.minimumDvrSize
     return typeof DVRSizeConfig !== 'undefined' && typeof DVRSizeConfig === 'number' && DVRSizeConfig
   }
+
+  get dvrSize() { return this.minimumDvrSizeConfig ? this.minimumDvrSizeConfig : DEFAULT_MINIMUM_DVR_SIZE }
 
   get config() { return this.options.html5TvsPlayback }
 

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -274,6 +274,7 @@ export default class HTML5TVsPlayback extends Playback {
 
   pause() {
     this.el.pause()
+    this.dvrEnabled && this._updateDvr(true)
   }
 
   seek(time) {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -6,6 +6,7 @@ import {
   READY_STATE_STAGES,
   UNKNOWN_ERROR,
   DEFAULT_MINIMUM_DVR_SIZE,
+  LIVE_STATE_THRESHOLD,
   getExtension,
 } from './utils/constants'
 
@@ -277,7 +278,16 @@ export default class HTML5TVsPlayback extends Playback {
 
   seek(time) {
     if (time < 0) return Log.warn(this.name, 'Attempting to seek to a negative time. Ignoring this operation.')
-    this.el.currentTime = time
+
+    let timeToSeek = time
+
+    // Assumes that is a live state if the time is within the LIVE_STATE_THRESHOLD of the end of the stream.
+    const dvrStatus = timeToSeek < this.duration - LIVE_STATE_THRESHOLD
+
+    this.dvrEnabled && this._updateDvr(dvrStatus)
+    this.el.seekable && this.el.seekable.start && (timeToSeek += this.el.seekable.start(0))
+
+    this.el.currentTime = timeToSeek
   }
 
   stop() {

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -69,6 +69,24 @@ describe('HTML5TVsPlayback', function() {
     expect(this.playback.el.tagName).toEqual('VIDEO')
   })
 
+  test('have a getter called mediaType', () => {
+    expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'mediaType').get).toBeTruthy()
+  })
+
+  describe('mediaType getter', () => {
+    test('returns Playback.LIVE if video.duration property is Infinity', () => {
+      this.playback.el = { duration: Infinity }
+
+      expect(this.playback.mediaType).toEqual(Playback.LIVE)
+    })
+
+    test('returns Playback.VOD if video.duration property is not Infinity', () => {
+      this.playback.el = { duration: 0 }
+
+      expect(this.playback.mediaType).toEqual(Playback.VOD)
+    })
+  })
+
   test('have a getter called isReady', () => {
     expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'isReady').get).toBeTruthy()
   })

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -186,6 +186,24 @@ describe('HTML5TVsPlayback', function() {
     expect(this.playback.isLive).toBeTruthy()
   })
 
+  test('have a getter called minimumDvrSizeConfig', () => {
+    expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'minimumDvrSizeConfig').get).toBeTruthy()
+  })
+
+  test('minimumDvrSizeConfig getter returns the value of a valid options.playback.minimumDvrSize config', () => {
+    this.playback.options.playback = { minimumDvrSize: 'invalid_config' }
+
+    expect(this.playback.minimumDvrSizeConfig).toBeFalsy()
+
+    this.playback.options.playback.minimumDvrSize = null
+
+    expect(this.playback.minimumDvrSizeConfig).toBeFalsy()
+
+    this.playback.options.playback.minimumDvrSize = 120
+
+    expect(this.playback.minimumDvrSizeConfig).toEqual(120)
+  })
+
   test('have a getter called events', () => {
     expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'events').get).toBeTruthy()
   })

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -757,12 +757,6 @@ describe('HTML5TVsPlayback', function() {
     })
   })
 
-  describe('getPlaybackType method', () => {
-    test('always returns VoD type', () => {
-      expect(this.playback.getPlaybackType()).toEqual(Playback.VOD)
-    })
-  })
-
   describe('play method', () => {
     test('sets _isStopped flag with false value', () => {
       expect(HTML5TVsPlayback.prototype._isStopped).toBeUndefined()
@@ -964,5 +958,9 @@ describe('HTML5TVsPlayback', function() {
 
   test('isPlaying method returns playing getter', () => {
     expect(this.playback.isPlaying()).toEqual(this.playback.playing)
+  })
+
+  test('getPlaybackType method returns mediaType getter', () => {
+    expect(this.playback.getPlaybackType()).toEqual(this.playback.mediaType)
   })
 })

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -139,7 +139,7 @@ describe('HTML5TVsPlayback', function() {
       expect(this.playback.duration).toEqual(this.playback.el.duration)
     })
 
-    test('returns the difference between video.seekable.end(0) and video.seekable.start(0) values for live content', () => {
+    test('returns the difference between the last and first seekable range values for live content', () => {
       const startTimeChunks = [0, 11, 101]
       const endTimeChunks = [10, 100, 1000]
 
@@ -149,10 +149,11 @@ describe('HTML5TVsPlayback', function() {
         seekable: {
           start: index => startTimeChunks[index],
           end: index => endTimeChunks[index],
+          length: 3,
         },
       }
 
-      expect(this.playback.duration).toEqual(10)
+      expect(this.playback.duration).toEqual(1000)
     })
   })
 

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -4,7 +4,7 @@ import mockConsole from 'jest-mock-console'
 import { Events, Core, Container, Playback, UIObject, version } from '@clappr/core'
 import HTML5TVsPlayback from './html5_playback'
 import DRMHandler from './drm/drm_handler'
-import { READY_STATE_STAGES } from './utils/constants'
+import { READY_STATE_STAGES, DEFAULT_MINIMUM_DVR_SIZE } from './utils/constants'
 
 const LOG_WARN_HEAD_MESSAGE = '%c[warn][html5_tvs_playback]'
 const LOG_INFO_HEAD_MESSAGE = '%c[info][html5_tvs_playback]'
@@ -202,6 +202,24 @@ describe('HTML5TVsPlayback', function() {
     this.playback.options.playback.minimumDvrSize = 120
 
     expect(this.playback.minimumDvrSizeConfig).toEqual(120)
+  })
+
+  test('have a getter called dvrSize', () => {
+    expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'dvrSize').get).toBeTruthy()
+  })
+
+  describe('dvrSize getter', () => {
+    test('returns the minimumDvrSizeConfig getter value if options.playback.minimumDvrSize is valid', () => {
+      this.playback.options.playback = { minimumDvrSize: 120 }
+
+      expect(this.playback.dvrSize).toEqual(120)
+    })
+
+    test('returns the DEFAULT_MINIMUM_DVR_SIZE value if options.playback.minimumDvrSize is invalid', () => {
+      this.playback.options.playback = { minimumDvrSize: 'invalid_config' }
+
+      expect(this.playback.dvrSize).toEqual(DEFAULT_MINIMUM_DVR_SIZE)
+    })
   })
 
   test('have a getter called events', () => {

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -134,8 +134,26 @@ describe('HTML5TVsPlayback', function() {
     expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'duration').get).toBeTruthy()
   })
 
-  test('duration getter returns video.duration property', () => {
-    expect(this.playback.duration).toEqual(this.playback.el.duration)
+  describe('duration getter', () => {
+    test('returns video.duration property for VoD content', () => {
+      expect(this.playback.duration).toEqual(this.playback.el.duration)
+    })
+
+    test('returns the difference between video.seekable.end(0) and video.seekable.start(0) values for live content', () => {
+      const startTimeChunks = [0, 11, 101]
+      const endTimeChunks = [10, 100, 1000]
+
+      jest.spyOn(this.playback, 'isLive', 'get').mockImplementation(() => true)
+
+      this.playback.el = {
+        seekable: {
+          start: index => startTimeChunks[index],
+          end: index => endTimeChunks[index],
+        },
+      }
+
+      expect(this.playback.duration).toEqual(10)
+    })
   })
 
   test('have a getter called ended', () => {

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -921,6 +921,37 @@ describe('HTML5TVsPlayback', function() {
       )
     })
 
+    test('calls _updateDvr method with current DVR status if dvrEnabled getter returns true', () => {
+      jest.spyOn(this.playback, 'duration', 'get').mockReturnValue(100)
+      jest.spyOn(this.playback, 'dvrEnabled', 'get').mockReturnValueOnce(false)
+      jest.spyOn(this.playback, '_updateDvr')
+      this.playback.seek(10)
+
+      expect(this.playback._updateDvr).not.toHaveBeenCalled()
+
+      jest.spyOn(this.playback, 'dvrEnabled', 'get').mockReturnValueOnce(true)
+      this.playback.seek(10)
+
+      expect(this.playback._updateDvr).toHaveBeenCalledTimes(1)
+      expect(this.playback._updateDvr).toHaveBeenCalledWith(true)
+
+      jest.spyOn(this.playback, 'dvrEnabled', 'get').mockReturnValueOnce(true)
+      this.playback.seek(99)
+
+      expect(this.playback._updateDvr).toHaveBeenCalledTimes(2)
+      expect(this.playback._updateDvr).toHaveBeenCalledWith(false)
+    })
+
+    test('use video.seekable.start(0) as basis to update current time', () => {
+      const startTimeChunks = [10, 50]
+
+      jest.spyOn(this.playback, 'duration', 'get').mockReturnValueOnce(100)
+      this.playback.el = { seekable: { start: index => startTimeChunks[index] } }
+      this.playback.seek(30)
+
+      expect(this.playback.el.currentTime).toEqual(40)
+    })
+
     test('sets received value on video.currentTime attribute', () => {
       this.playback.seek(10)
 

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -675,6 +675,23 @@ describe('HTML5TVsPlayback', function() {
     })
   })
 
+  describe('_updateDvr method', () => {
+    test('triggers PLAYBACK_DVR event with received status', () => {
+      const cb = jest.fn()
+      this.playback.listenToOnce(this.playback, Events.PLAYBACK_DVR, cb)
+      this.playback._updateDvr(true)
+
+      expect(cb).toHaveBeenCalledTimes(1)
+      expect(cb).toHaveBeenCalledWith(true)
+
+      this.playback.listenToOnce(this.playback, Events.PLAYBACK_DVR, cb)
+      this.playback._updateDvr(false)
+
+      expect(cb).toHaveBeenCalledTimes(2)
+      expect(cb).toHaveBeenCalledWith(false)
+    })
+  })
+
   describe('_onCanPlay callback', () => {
     test('sets _isBuffering flag with false value if the current value is true', () => {
       this.playback._isBuffering = true

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -172,6 +172,20 @@ describe('HTML5TVsPlayback', function() {
     expect(this.playback.buffering).toEqual(this.playback._isBuffering)
   })
 
+  test('have a getter called isLive', () => {
+    expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'isLive').get).toBeTruthy()
+  })
+
+  test('isLive getter returns the check if the mediaType getter returns the Playback.LIVE value', () => {
+    jest.spyOn(this.playback, 'mediaType', 'get').mockReturnValueOnce(Playback.VOD)
+
+    expect(this.playback.isLive).toBeFalsy()
+
+    jest.spyOn(this.playback, 'mediaType', 'get').mockReturnValueOnce(Playback.LIVE)
+
+    expect(this.playback.isLive).toBeTruthy()
+  })
+
   test('have a getter called events', () => {
     expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'events').get).toBeTruthy()
   })

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -222,6 +222,30 @@ describe('HTML5TVsPlayback', function() {
     })
   })
 
+  test('have a getter called dvrEnabled', () => {
+    expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'dvrEnabled').get).toBeTruthy()
+  })
+
+  test('dvrEnabled getter returns the check of the isLive is truthy and if the duration is greater or equal the dvrSize value', () => {
+    jest.spyOn(this.playback, 'isLive', 'get').mockReturnValueOnce(false)
+    jest.spyOn(this.playback, 'duration', 'get').mockReturnValueOnce(100)
+    jest.spyOn(this.playback, 'dvrSize', 'get').mockReturnValueOnce(60)
+
+    expect(this.playback.dvrEnabled).toBeFalsy()
+
+    jest.spyOn(this.playback, 'isLive', 'get').mockReturnValueOnce(true)
+    jest.spyOn(this.playback, 'duration', 'get').mockReturnValueOnce(10)
+    jest.spyOn(this.playback, 'dvrSize', 'get').mockReturnValueOnce(60)
+
+    expect(this.playback.dvrEnabled).toBeFalsy()
+
+    jest.spyOn(this.playback, 'isLive', 'get').mockReturnValueOnce(true)
+    jest.spyOn(this.playback, 'duration', 'get').mockReturnValueOnce(120)
+    jest.spyOn(this.playback, 'dvrSize', 'get').mockReturnValueOnce(60)
+
+    expect(this.playback.dvrEnabled).toBeTruthy()
+  })
+
   test('have a getter called events', () => {
     expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'events').get).toBeTruthy()
   })

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -908,6 +908,15 @@ describe('HTML5TVsPlayback', function() {
 
       expect(this.playback.el.pause).toHaveBeenCalledTimes(1)
     })
+
+    test('calls _updateDvr with true value if dvrEnabled getter is truthy', () => {
+      jest.spyOn(this.playback, 'dvrEnabled', 'get').mockReturnValueOnce(true)
+      jest.spyOn(this.playback, '_updateDvr')
+      this.playback.pause()
+
+      expect(this.playback._updateDvr).toHaveBeenCalledTimes(1)
+      expect(this.playback._updateDvr).toHaveBeenCalledWith(true)
+    })
   })
 
   describe('seek method', () => {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -36,6 +36,8 @@ export const MIME_TYPES_BY_EXTENSION = {
 
 export const DEFAULT_MINIMUM_DVR_SIZE = 60 // in seconds
 
+export const LIVE_STATE_THRESHOLD = 3 // in seconds
+
 export const getExtension = url => {
   const urlWithoutParameters = url.split('?')[0] //eslint-disable-line
   const match = urlWithoutParameters.match(/(\.[A-Z0-9]+)/gi)

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -34,6 +34,8 @@ export const MIME_TYPES_BY_EXTENSION = {
   ism: MIME_TYPES.VND_MS_SSTR,
 }
 
+export const DEFAULT_MINIMUM_DVR_SIZE = 60 // in seconds
+
 export const getExtension = url => {
   const urlWithoutParameters = url.split('?')[0] //eslint-disable-line
   const match = urlWithoutParameters.match(/(\.[A-Z0-9]+)/gi)


### PR DESCRIPTION
## Summary 

**DISCLAIMER: To merge this PR, is mandatory the previous merge of the #1, #2, and #3.**

Refactor some methods that interact with the media to support live content and create a new option `options.playback.minimumDvrSize` to define when the DVR feature activates.

## Changes
 
- `utils/constants.js`:
  - Create `DEFAULT_MINIMUM_DVR_SIZE`;
    - Constant to be used when one custom DVR size config doesn't exist.
  - Create `LIVE_STATE_THRESHOLD`;
    -  Constant to be used on the definition of when the DVR state is `true` after a seek operation.
- `html5_playback.js`:
  - Create `mediaType` getter;
    - Returns the type of the current media based on the `video.duration` attribute.
  -  Refactor `duration` getter to return a meaningful value on live contents;
    - Return the difference between the `end` and `start` seekable ranges for live contents.
  - Create `isLive` getter;
    - Returns the check if the `mediaType` getter response is `live`.
  - Create `minimumDvrSizeConfig` getter;
    - Returns the `options.playback.minimumDvrSize` config if has a valid value.
  -  Create `dvrSize` getter;
    - Returns `minimumDvrSizeConfig` value if is a valid value. If not, returns the `DEFAULT_MINIMUM_DVR_SIZE` value.
  -  Create `dvrEnabled` getter;
    - Returns `true` if is a live content and the `duration` getter is equal or greater than `dvrSize` value.
  - Create `_updateDvr` method;
    - Trigger events with the current DVR state;
  - Refactor `pause` method;
    - Calls `_updateDvr` method to update DVR state to `true` if `dvrEnabled` getter is truthy;
  -  Refactor `seek` method;
    - Adapt the operations to update `video.currentTime` property to works correctly with live contents;
  - Refactor `getPlaybackType` method;
    - Proxy to `mediaType` getter;
  - Move `config` getter to group inline getters;
- `html5_playback.test.js`:
  - Cover with tests all the code added on the `html5_playback.js` file;

## How to test

- Play one live media;
  - The `duration` getter should return one integer value.
  - The `mediaType` getter should return the `live` string.
  - The `isLive` getter should return the `true`.
- Add one listener for the `PLAYBACK_DVR` event;

```javascript
var onReadyCallback = function() {
  var onPlaybackDVRCallback = function(status) { console.log('triggered with dvr status: ', status); };
  this.core.activePlayback.listenTo(this.core.activePlayback, Clappr.Events.PLAYBACK_DVR,  onPlaybackDVRCallback});
};

var player = new Clappr.Player({
  ...
  events: { onReady: onReadyCallback },
  ...
});
```
- Seek to one point of the media;
  - The `onPlaybackDVRCallback` should be called if `dvrEnabled` is truthy and the time to seek is less than the difference between the `duration` getter and the `LIVE_STATE_THRESHOLD` value.
  - The current time should be updated to the `duration` value if the time to seek is greater than the `video.duration` property.
  - The current time should be updated to the `video.seekable.start(0)` value if the time to seek is less than the `video.seekable.start(0)` value.

### Without `options.playback.minimumDvrSize` configured:

- Play one live media;
  - The `minimumDvrSizeConfig` getter should return `false`.
  - The `dvrSize` getter should return the `DEFAULT_MINIMUM_DVR_SIZE` value (currently is `60`).
- Pause the media;
  - The `dvrEnabled` getter should return `false` if the media duration is less than the `DEFAULT_MINIMUM_DVR_SIZE` value.
  - The `dvrEnabled` getter should return `true` if the media duration is equal or greater than the `DEFAULT_MINIMUM_DVR_SIZE` value.
  - The `onPlaybackDVRCallback` should be called.

### With `options.playback.minimumDvrSize` configured:

- Play one live media;
  - The `minimumDvrSizeConfig` getter should return the `options.playback.minimumDvrSize` value.
  - The `dvrSize` getter should return the `minimumDvrSizeConfig` value.
- Pause the media;
  - The `dvrEnabled` getter should return `false` if the media duration is less than the `options.playback.minimumDvrSize` value.
  - The `dvrEnabled` getter should return `true` if the media duration is equal or greater than the `options.playback.minimumDvrSize` value.
  - The `onPlaybackDVRCallback` should be called.