### PR TITLE
Add support to manipulate multi audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,22 @@ Group all DRM-related config. The currently available configs are:
 | `playback.duration` | Returns the duration of the current media. | `{Number} - time in seconds` |
 | `playback.ended` | Indicates whether the media has finished playing. | `{Boolean}` |
 | `playback.buffering` | Indicates whether the media on the buffering state. | `{Boolean}` |
+| `playback.audioTracks` | Returns the [audioTrackList](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList) of the current media. | `{Object}` |
+| `playback.currentAudioTrack` | Returns the enabled [audioTrack](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack) of the current media. | `{Object}` |
 | `playback.isLive` | Indicates whether the media is a live content. | `{Boolean}` |
 | `playback.minimumDvrSizeConfig` | Returns `options.playback.minimumDvrSize` if is configured and is a valid value. | `{Number}` |
 | `playback.dvrSize` | Returns `playback.minimumDvrSizeConfig` if is a valid value or one default value. (Currently, is 60 seconds) | `{Number}` |
 | `playback.dvrEnabled` | Indicates whether the live media is on DVR state. | `{Boolean}` |
 
+| setter | arguments | description |
+|--------|-----------|-------------|
+| `playback.currentAudioTrack` | {[audioTrack](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack)} | Sets the received audio track as the current audio if it's in the current media's audioTrackList. |
+
 ## Next Steps
 - [x] Media with DRM;
 - [x] Live media;
 - [ ] subtitles/closed captions;
-- [ ] multi-audio;
+- [x] multi-audio;
 - [ ] Advertisement;
 
 ## Development

--- a/public/javascript/clappr-config.js
+++ b/public/javascript/clappr-config.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 var mp4Source = 'http://clappr.io/highline.mp4';
-var hlsSource = 'http://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8';
+var hlsSource = 'https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8';
 var smoothStreamingSource = 'http://playready.directtaps.net/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest';
 Clappr.Log.setLevel(Clappr.Log.LEVEL_INFO);
 
@@ -27,7 +27,7 @@ var searchParams;
 window.URLSearchParams && (searchParams = new window.URLSearchParams(window.location.search));
 
 var player = new Clappr.Player({
-  source: searchParams && searchParams.get('source') || mp4Source,
+  source: searchParams && searchParams.get('source') || hlsSource,
   height: searchParams && searchParams.get('height') || '100%',
   width: searchParams && searchParams.get('width') || '100%',
   tvsKeyMapping: { deviceToMap: 'panasonic' },

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -48,6 +48,8 @@ export default class HTML5TVsPlayback extends Playback {
 
   get buffering() { return this._isBuffering }
 
+  get audioTracks() { return this.el.audioTracks || {} }
+
   get isLive() { return this.mediaType === Playback.LIVE }
 
   get minimumDvrSizeConfig() {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -50,6 +50,15 @@ export default class HTML5TVsPlayback extends Playback {
 
   get audioTracks() { return this.el.audioTracks || {} }
 
+  get currentAudioTrack() { return Object.values(this.audioTracks).find(track => track.enabled) }
+
+  set currentAudioTrack(selectedTrack) {
+    const confirmedTrack = Object.values(this.audioTracks).find(track => track === selectedTrack)
+    confirmedTrack
+      ? confirmedTrack.enabled = true
+      : Log.warn(this.name, 'The received audio track is not available on the playback.audioTracks object')
+  }
+
   get isLive() { return this.mediaType === Playback.LIVE }
 
   get minimumDvrSizeConfig() {

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -185,6 +185,28 @@ describe('HTML5TVsPlayback', function() {
     })
   })
 
+  test('currentAudioTrack getter returns the enabled audio track on playback.audioTracks', () => {
+    this.playback.el = { audioTracks: { 0: { enabled: false }, 1: { enabled: true }, 2: { enabled: false } } }
+
+    expect(this.playback.currentAudioTrack).toEqual(this.playback.audioTracks[1])
+  })
+
+  test('currentAudioTrack setter only set one audio track available on the playback.audioTracks', () => {
+    this.playback.el = { audioTracks: { 0: { enabled: false }, 1: { enabled: false }, 2: { enabled: false } } }
+    this.playback.currentAudioTrack = {}
+
+    expect(console.log).toHaveBeenCalledWith(
+      LOG_WARN_HEAD_MESSAGE,
+      LOG_WARN_STYLE,
+      'The received audio track is not available on the playback.audioTracks object',
+    )
+
+    // eslint-disable-next-line prefer-destructuring
+    this.playback.currentAudioTrack = this.playback.el.audioTracks[1]
+
+    expect(this.playback.currentAudioTrack).toEqual(this.playback.audioTracks[1])
+  })
+
   test('have a getter called isLive', () => {
     expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'isLive').get).toBeTruthy()
   })

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -173,6 +173,18 @@ describe('HTML5TVsPlayback', function() {
     expect(this.playback.buffering).toEqual(this.playback._isBuffering)
   })
 
+  describe('audioTracks getter', () => {
+    test('returns the video.audioTracks property', () => {
+      expect(this.playback.audioTracks).toEqual(this.playback.el.audioTracks)
+    })
+
+    test('returns empty object if video.audioTracks property doesn\'t exists', () => {
+      this.playback.el = { audioTracks: null }
+
+      expect(this.playback.audioTracks).toEqual({})
+    })
+  })
+
   test('have a getter called isLive', () => {
     expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'isLive').get).toBeTruthy()
   })


### PR DESCRIPTION
## Summary

Add getters and setters to manipulate multi-audio.

## Changes

- `html5_playback.js`:
  - Create `audioTracks` getter;
    - Returns the [audioTrackList](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList) property.
  - Create `currentAudioTRack` getter;
    - Returns the enabled [audio track](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack) of the audio track list.
  - Create `currentAudioTRack` setter;
    - Sets the received track as the current audio track if it's one track of the audio tracklist.
- `html5_playback.test.js`:
  - Cover with tests all new code;
- `README.md`:
  - Add info about all new code;
- `public/javascript/clappr-config.js`:
  - Update `hlsSource`;
    - Now is a source with multi-audio.


## How to test

- Play one media with multi-audio;
  - E.g.: The `hlsSource`.
- Access the `audioTracks` getter;
  - Should returns one valid audio tracks list.
- Access the `currentAudioTrack` getter;
  - Should returns the enabled audio track.
- Set one new valid  audio track on the `currentAudioTrack` setter;
  - E.g.: `playback.currentAudioTrack = playback.audioTracks[2]`
  - The `currentAudioTrack` getter should return the new audio track. 