### PR TITLE
Fix video aspect ratio

### DIFF
--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -29,6 +29,8 @@ export default class HTML5TVsPlayback extends Playback {
 
   get tagName() { return 'video' }
 
+  get attributes() { return { width: '100%' } }
+
   get mediaType() { return this.el.duration === Infinity ? Playback.LIVE : Playback.VOD }
 
   get isReady() { return this.el.readyState >= READY_STATE_STAGES.HAVE_CURRENT_DATA }

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -69,6 +69,10 @@ describe('HTML5TVsPlayback', function() {
     expect(this.playback.el.tagName).toEqual('VIDEO')
   })
 
+  test('attributes getter returns the width attribute that will be added on the plugin DOM element', () => {
+    expect(`${this.playback.el.width}%`).toEqual(this.playback.attributes.width)
+  })
+
   test('have a getter called mediaType', () => {
     expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this.playback), 'mediaType').get).toBeTruthy()
   })


### PR DESCRIPTION
## Summary

Sets the `width` property on the video element to guarantee the right video aspect ratio.

## Changes

- `html5_playback.js`:
  - Overwrite the `attributes` getter to return the `width` property with the value of `100%`;

## How to test

- Play any media;
  - The video aspect ratio should respect the viewport.

## A picture/video tells a thousand words

### Before this PR

https://user-images.githubusercontent.com/5631063/127072294-0522669c-85dc-4dff-b03f-4bc3636503df.mp4

### After this PR

https://user-images.githubusercontent.com/5631063/127072405-88a8678d-d063-4fd3-bfb7-c7dd50952e85.mp4
