### PR TITLE
DRM - Support full challenge license acquisition

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Clappr HTML5 playback for smart TVs devices that implement the [HbbTV 2.0.1 sp
 * Supports VoD and Live content;
   * Current mime types: [`video/mp4`, `application/vnd.apple.mpegurl`, `application/vnd.ms-sstr+xml`].
 * Supports DRM content;
-  * Using [`oipfDrmAgent`](https://www.oipf.tv/docs/OIPF-T1-R2_Specification-Volume-5-Declarative-Application-Environment-v2_3-2014-01-24.pdf#page=121). (Only with Playready `post-acquisition` at the moment)
+  * Using [`oipfDrmAgent`](https://www.oipf.tv/docs/OIPF-T1-R2_Specification-Volume-5-Declarative-Application-Environment-v2_3-2014-01-24.pdf#page=121).
 
 ## Configuration
 The options for the playback must be placed in the `html5TvsPlayback` property as shown below:
@@ -33,6 +33,7 @@ var player = new Clappr.Player({
   html5TvsPlayback: {
     drm: {
       licenseServerURL: 'https://my-license-server.com/keys/my-key',
+      xmlLicenceAcquisition: '<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03 PlayReadyHeader" version="4.0.0.0"><DATA><PROTECTINFO><ALGID>AESCTR</ALGID><KEYLEN>16</KEYLEN></PROTECTINFO><KID>base64-encoded kid</KID><CHECKSUM>checksum of the content key for verification</CHECKSUM><LA_URL>URL for license acquisition</LA_URL></DATA></WRMHEADER>',
     },
   },
 });
@@ -42,7 +43,10 @@ var player = new Clappr.Player({
 Group all DRM-related config. The currently available configs are:
 
 * #### `licenseServerURL {String}`
-  The license server URL used on the license acquisition. This config is mandatory to play content with DRM.
+  The license server URL used on the license acquisition. Only used to do the post acquisition.
+
+* #### `xmlLicenceAcquisition {String}`
+  The part of XML that contains all necessary info to do the full challenge of license acquisition. See more about the PlayReady Header Specification [here](https://docs.microsoft.com/en-us/playready/specifications/playready-header-specification).
 
 ## API Documentation
 

--- a/public/javascript/clappr-config.js
+++ b/public/javascript/clappr-config.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
-var mp4Source = 'http://clappr.io/highline.mp4';
-var hlsSource = 'https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8';
-var smoothStreamingSource = 'http://playready.directtaps.net/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest';
+var mp4Resource = 'http://clappr.io/highline.mp4';
+var hlsResource = 'https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8';
+var mssResource = 'http://test.playready.microsoft.com/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest';
 Clappr.Log.setLevel(Clappr.Log.LEVEL_INFO);
 
 var onReadyCallback = function() {
@@ -27,7 +27,7 @@ var searchParams;
 window.URLSearchParams && (searchParams = new window.URLSearchParams(window.location.search));
 
 var player = new Clappr.Player({
-  source: searchParams && searchParams.get('source') || hlsSource,
+  source: searchParams && searchParams.get('source') || hlsResource,
   height: searchParams && searchParams.get('height') || '100%',
   width: searchParams && searchParams.get('width') || '100%',
   tvsKeyMapping: { deviceToMap: 'panasonic' },

--- a/public/javascript/clappr-config.js
+++ b/public/javascript/clappr-config.js
@@ -32,6 +32,11 @@ var player = new Clappr.Player({
   width: searchParams && searchParams.get('width') || '100%',
   tvsKeyMapping: { deviceToMap: 'panasonic' },
   playback: { controls: true },
+  // html5TvsPlayback: { drm: {
+  //   fullChallenge: true,
+  //   xmlLicenceAcquisition: '<WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.0.0.0"><DATA><PROTECTINFO><KEYLEN>16</KEYLEN><ALGID>AESCTR</ALGID></PROTECTINFO><KID>AAAAEAAQABAQABAAAAAAAQ==</KID><CHECKSUM>5TzIYQ2hrOY=</CHECKSUM><LA_URL>http://test.playready.microsoft.com/service/rightsmanager.asmx</LA_URL></DATA></WRMHEADER>',
+  //   licenseServerURL: 'http://test.playready.microsoft.com/service/rightsmanager.asmx',
+  // } },
   plugins: [window.TVsKeyMappingPlugin.Watcher, window.HTML5TVsPlayback],
   events: { onReady: onReadyCallback },
 });

--- a/public/javascript/clappr-config.js
+++ b/public/javascript/clappr-config.js
@@ -2,6 +2,8 @@
 var mp4Resource = 'http://clappr.io/highline.mp4';
 var hlsResource = 'https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8';
 var mssResource = 'http://test.playready.microsoft.com/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest';
+var mssResourceWithPlayReady = 'http://playready.directtaps.net/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest';
+
 Clappr.Log.setLevel(Clappr.Log.LEVEL_INFO);
 
 var onReadyCallback = function() {

--- a/src/drm/drm_handler.js
+++ b/src/drm/drm_handler.js
@@ -73,7 +73,7 @@ export function sendLicenseRequest(config = {}, onSuccess = () => {}, onFail = (
 
     if (resultCode < 2) {
       Log.error('DRMHandler', 'Error at onDRMRightsError call', errorMessage[resultCode])
-      errorCallback(errorMessage[resultCode])
+      return errorCallback(errorMessage[resultCode])
     }
   }
 
@@ -90,12 +90,12 @@ export function sendLicenseRequest(config = {}, onSuccess = () => {}, onFail = (
       5: 'DRM: Unknown DRM system',
     }
 
-    if (resultCode > 0) {
+    if (resultCode !== 0) {
       Log.error('DRMHandler', 'Error at onDRMMessageResult call', errorMessage[resultCode])
-      errorCallback(errorMessage[resultCode])
+      return errorCallback(errorMessage[resultCode])
     }
 
-    successCallback()
+    return successCallback()
   }
 
   try {
@@ -104,7 +104,7 @@ export function sendLicenseRequest(config = {}, onSuccess = () => {}, onFail = (
     oipfdrmagent.sendDRMMessage(MESSAGE_TYPE, xmlLicenceAcquisition, DRM_SYSTEM_ID)
   } catch (error) {
     Log.error('DRMHandler', 'Error at sendDRMMessage call', error.message)
-    errorCallback(error.message)
+    return errorCallback(error.message)
   }
 }
 

--- a/src/drm/drm_handler.js
+++ b/src/drm/drm_handler.js
@@ -3,6 +3,18 @@ import { Log } from '@clappr/core'
 const MESSAGE_TYPE = 'application/vnd.ms-playready.initiator+xml'
 const DRM_SYSTEM_ID = 'urn:dvb:casystemid:19219'
 
+export const getFullChallengeMessageTemplate = header => {
+  const template = '<?xml version="1.0" encoding="utf-8"?>'
+  + '<PlayReadyInitiator xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols/">'
+  + '<LicenseAcquisition>'
+  + '<Header>'
+  + `${header}`
+  + '</Header>'
+  + '</LicenseAcquisition>'
+  + '</PlayReadyInitiator>'
+  return template
+}
+
 export const getLicenseOverrideMessageTemplate = licenseServerURL => {
   const template = '<?xml version="1.0" encoding="utf-8"?>'
   + '<PlayReadyInitiator xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols/">'
@@ -48,9 +60,9 @@ export function sendLicenseRequest(config = {}, onSuccess = () => {}, onFail = (
       : document.body.appendChild(oipfdrmagent)
   }
 
-  !config.licenseServerURL
-    && Log.warn('DRMHandler', 'No one license server was found. The expected result for this behavior is to clear the current license.')
-  const xmlLicenceAcquisition = getLicenseOverrideMessageTemplate(config.licenseServerURL)
+  const xmlLicenceAcquisition = config.xmlLicenceAcquisition
+    ? getFullChallengeMessageTemplate(config.xmlLicenceAcquisition)
+    : getLicenseOverrideMessageTemplate(config.licenseServerURL)
 
   const drmRightsErrorHandler = resultCode => {
     const errorMessage = {

--- a/src/drm/drm_handler.test.js
+++ b/src/drm/drm_handler.test.js
@@ -174,8 +174,9 @@ describe('DRMHandler', function() {
         const errorCb = jest.fn()
         sendLicenseRequest(this.config, successCb, errorCb)
         drmAgentElement.onDRMMessageResult(0, 'a error message', 1)
+        drmAgentElement.onDRMMessageResult(0, 'success', 0)
 
-        expect(errorCb).toHaveBeenCalledWith('DRM: Unspecified error')
+        expect(errorCb).toHaveBeenCalledTimes(1)
       })
 
       test('calls the successCallback if the received result code is 0', () => {

--- a/src/drm/drm_handler.test.js
+++ b/src/drm/drm_handler.test.js
@@ -1,6 +1,7 @@
 import mockConsole from 'jest-mock-console'
 
 import DRMHandler, {
+  getFullChallengeMessageTemplate,
   getLicenseOverrideMessageTemplate,
   getClearMessageTemplate,
   createDrmAgent,
@@ -21,9 +22,25 @@ describe('DRMHandler', function() {
   test('only exports methods to handle with license request', () => {
     expect(DRMHandler.sendLicenseRequest).toBeDefined()
     expect(DRMHandler.clearLicenseRequest).toBeDefined()
+    expect(DRMHandler.getFullChallengeMessageTemplate).toBeUndefined()
     expect(DRMHandler.getLicenseOverrideMessageTemplate).toBeUndefined()
     expect(DRMHandler.getClearMessageTemplate).toBeUndefined()
     expect(DRMHandler.createDrmAgent).toBeUndefined()
+  })
+
+  describe('getFullChallengeMessageTemplate method', () => {
+    test('returns XML template with the composition of the received XML', () => {
+      const header = 'fake_xml'
+      const result = '<?xml version="1.0" encoding="utf-8"?>'
+      + '<PlayReadyInitiator xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols/">'
+      + '<LicenseAcquisition>'
+      + `<Header>${header}</Header>`
+      + '</LicenseAcquisition>'
+      + '</PlayReadyInitiator>'
+      const response = getFullChallengeMessageTemplate(header)
+
+      expect(response).toEqual(result)
+    })
   })
 
   describe('getLicenseOverrideMessageTemplate method', () => {
@@ -98,19 +115,9 @@ describe('DRMHandler', function() {
     })
 
     test('appends drmAgent on document.body if any external scope is received', () => {
-      sendLicenseRequest(this.config)
+      sendLicenseRequest({ xmlLicenceAcquisition: 'fake_xml' })
 
       expect(document.body.firstChild.id).toEqual('oipfdrmagent')
-    })
-
-    test('logs warn message if no one licenser server URL is received', () => {
-      sendLicenseRequest()
-
-      /* eslint-disable-next-line no-console */
-      expect(console.log).toHaveBeenNthCalledWith(1,
-        LOG_WARN_HEAD_MESSAGE,
-        LOG_WARN_STYLE,
-        'No one license server was found. The expected result for this behavior is to clear the current license.')
     })
 
     test('calls the errorCallback if the sendDRMMessage call fails', () => {
@@ -158,7 +165,7 @@ describe('DRMHandler', function() {
     })
 
     describe('at onDRMMessageResult callback', () => {
-      test('calls the errorCallback if the received result code is greater than 0', () => {
+      test('calls the errorCallback if the received result code is nonzero', () => {
         document.body.appendChild(createDrmAgent())
         const drmAgentElement = document.getElementById('oipfdrmagent')
         drmAgentElement.sendDRMMessage = () => {}

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -119,7 +119,7 @@ export default class HTML5TVsPlayback extends Playback {
     const currentSource = this.$sourceElement && this.$sourceElement.src
     if (sourceURL === currentSource) return
 
-    this.config && this.config.drm && this.config.drm.licenseServerURL && !this._drmConfigured
+    this.config && this.config.drm && this.config.drm && !this._drmConfigured
       ? DRMHandler.sendLicenseRequest.call(this, this.config.drm, this._onDrmConfigured, this._onDrmError)
       : this._setSourceOnVideoTag(sourceURL)
   }

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -119,7 +119,7 @@ export default class HTML5TVsPlayback extends Playback {
     const currentSource = this.$sourceElement && this.$sourceElement.src
     if (sourceURL === currentSource) return
 
-    this.config && this.config.drm && this.config.drm && !this._drmConfigured
+    this.config && this.config.drm && !this._drmConfigured
       ? DRMHandler.sendLicenseRequest.call(this, this.config.drm, this._onDrmConfigured, this._onDrmError)
       : this._setSourceOnVideoTag(sourceURL)
   }

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -600,7 +600,7 @@ describe('HTML5TVsPlayback', function() {
       expect(this.playback._setSourceOnVideoTag).not.toHaveBeenCalled()
     })
 
-    test('sets license server if one license server URL is configured and _drmConfigured flag is false', () => {
+    test('sets license server if config.drm exists and _drmConfigured flag is false', () => {
       const { core, container } = setupTest({ src: URL_VIDEO_MP4_EXAMPLE, html5TvsPlayback: { drm: { licenseServerURL: 'http://fake-domain.com/license_server/playready' } } })
       core.activeContainer = container
 


### PR DESCRIPTION
## Summary 

Adds the possibility to do the full challenge DRM license acquisition. To make it available, this PR creates one new option (`html5TvsPlayback.drm.xmlLicenceAcquisition`) to receives the necessary [PlayReady Header](https://docs.microsoft.com/en-us/playready/specifications/playready-header-specification) and applies the necessary adaptations on the playback code.

Also, updates the info about DRM config on the README and adds DRM config example on the local demo page config.

## Changes

- `src/drm`:
  - Creates `getFullChallengeMessageTemplate` to mount the full challenge XML license acquisition;
  - Returns callbacks to stop license acquisition process; 
- `html5_playback.js`:
  - Simplifies condition to trigger the DRM license acquisition flow;
- `README.md`:
  - Update info about DRM config;
- `public/clappr-config.js`:
  - Update media example references;
  - Adds media example with PlayReady DRM;
  - Adds DRM config example;

## How to test

- Play one media with DRM (like the `mssResourceWithPlayReady`);
- Set the `html5TvsPlayback.drm.xmlLicenceAcquisition` config;
- Play the media;
  - The media should play as expected.
- Remove the `html5TvsPlayback.drm.xmlLicenceAcquisition` config;
- Play the media;
  - The media should not play.