### PR TITLE
Feature: add audio track related events and create interface to audio track data

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "env": { "browser": true, "node": true, "jest": true },
   "globals": { "Clappr": true,"$": true, "Promise": true },
   "extends": ["eslint:recommended"],
-  "parserOptions": { "sourceType": "module", "ecmaVersion": 2018 },
+  "parserOptions": { "sourceType": "module", "ecmaVersion": 2020 },
   "rules": {
     // Possible Errors
     "getter-return": ["error", { "allowImplicit": true }], // overrides eslint:recommended

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Group all DRM-related config. The currently available configs are:
 | `playback.getDuration (deprecated)` |  | This method only exists for backward compatibility reasons. Prefer duration getter. |
 | `playback.isPlaying (deprecated)` |  | This method only exists for backward compatibility reasons. Prefer playing getter. |
 | `playback.getPlaybackType (deprecated)` |  | This method only exists for backward compatibility reasons. Prefer mediaType getter. |
+| `playback.switchAudioTrack` | `{String} - track id` | Updates the current audio track to the one with the provided id. |
 
 | getter | description | response |
 |--------|-------------|----------|
@@ -73,16 +74,31 @@ Group all DRM-related config. The currently available configs are:
 | `playback.duration` | Returns the duration of the current media. | `{Number} - time in seconds` |
 | `playback.ended` | Indicates whether the media has finished playing. | `{Boolean}` |
 | `playback.buffering` | Indicates whether the media on the buffering state. | `{Boolean}` |
-| `playback.audioTracks` | Returns the [audioTrackList](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList) of the current media. | `{Object}` |
-| `playback.currentAudioTrack` | Returns the enabled [audioTrack](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack) of the current media. | `{Object}` |
+| `playback.audioTracks` | Returns a list of audio tracks currently available. | [`{AudioTrack[]}`](#audiotrack) |
+| `playback.currentAudioTrack` | Returns the audio track currenlty in use. | [`{AudioTrack}`](#audiotrack) |
 | `playback.isLive` | Indicates whether the media is a live content. | `{Boolean}` |
 | `playback.minimumDvrSizeConfig` | Returns `options.playback.minimumDvrSize` if is configured and is a valid value. | `{Number}` |
 | `playback.dvrSize` | Returns `playback.minimumDvrSizeConfig` if is a valid value or one default value. (Currently, is 60 seconds) | `{Number}` |
 | `playback.dvrEnabled` | Indicates whether the live media is on DVR state. | `{Boolean}` |
 
-| setter | arguments | description |
-|--------|-----------|-------------|
-| `playback.currentAudioTrack` | {[audioTrack](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack)} | Sets the received audio track as the current audio if it's in the current media's audioTrackList. |
+## Types
+#### `AudioTrack`
+```javascript
+/**
+ * An object representing a single audio track.
+ * @typedef {Object} AudioTrack
+ * @property {String} id - A unique identifier for the track. Used to identify it among the others.
+ * @property {String} language - The language of the track (e.g., 'en', 'pt-BR').
+ * @property {String} label - An optional label to be used in the UI to describe the track.
+ * @property {String} kind - The category this track belongs to (e.g., 'main', 'description').
+ */
+{
+  id: '0',
+  language: 'en',
+  label: 'English (audio description)',
+  kind: 'description',
+}
+```
 
 ## Next Steps
 - [x] Media with DRM;


### PR DESCRIPTION
## Summary

This PR adds two events to the playback:
- `PLAYBACK_AUDIO_CHANGED`: event trigged when the audio track changes during playback;
- `PLAYBACK_AUDIO_AVAILABLE`: event trigged to notify the currently available audio tracks on the stream.

Furthermore, in order to standardize the audio track data provided to other plugins and clients of the playback, a new interface is introduced to represent it. It is heavily inspired by the [AudioTrack](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack) object.

## Changes
- html5_playback:
  - changed public properties `currentAudioTrack` and `audioTracks` to use the new audio track interface;
  - added public method `switchAudioTrack` to change the audio track;
  - added two events related to audio, namely `PLAYBACK_AUDIO_CHANGED` and `PLAYBACK_AUDIO_AVAILABLE`.


## How to test
1) Use the @clappr/core version of [this PR](https://github.com/clappr/clappr-core/pull/68/files)
2) Play a stream with multiple audio tracks (ex: https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8);
3) Add two event listeners on the playback scope: one for `Events.PLAYBACK_AUDIO_CHANGED` and the other for `Events.PLAYBACK_AUDIO_AVAILABLE`;
4) Verify that they are being trigged at the right moment and with the correct payload.