### PR TITLE
fix(audio): resolve muted audio issues when switching audio

### DIFF
--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -60,7 +60,8 @@ export default class HTML5TVsPlayback extends Playback {
     if (!this.el.audioTracks) return null
 
     const track = Object.values(this.el.audioTracks).find(track => track.enabled)
-    return this._formatAudioTrack(track)
+
+    return track && this._formatAudioTrack(track)
   }
 
   get isLive() { return this.mediaType === Playback.LIVE }
@@ -331,7 +332,10 @@ export default class HTML5TVsPlayback extends Playback {
     const track = this.el.audioTracks?.getTrackById(id)
     if (!track || track.enabled) return
 
-    track.enabled = true
+    Object.values(this.el.audioTracks).forEach(track => {
+      track.enabled = track.id === id
+    })
+
     this.trigger(Events.PLAYBACK_AUDIO_CHANGED, this._formatAudioTrack(track))
   }
 

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -31,41 +31,28 @@ const setupTest = (options = {}) => {
 // https://developer.mozilla.org/en-US/docs/Web/API/AudioTrackList
 const createAudioTrackListStub = () => {
   const tracks = {}
-  const updateEnabledProperty = (trackId, value) => {
-    Object.values(tracks).forEach(track => {
-      if (track.id === trackId)
-        track._enabled = value
-      else
-        track._enabled = value ? false : this._enabled
-    })
-  }
-  const createAudioTrack = trackInfo => ({
-    ...trackInfo,
-    get enabled() { return this._enabled },
-    set enabled(value) { updateEnabledProperty(this.id, value) },
-  })
 
   Object.defineProperties(tracks, {
     addEventListener: { value: jest.fn() },
     getTrackById: { value: id => tracks[id] },
     0: {
-      value: createAudioTrack({
+      value: {
         id: '0',
         language: 'en',
         kind: 'description',
         label: 'English (describes video)',
-        _enabled: true,
-      }),
+        enabled: true,
+      },
       enumerable: true,
     },
     1: {
-      value: createAudioTrack({
+      value: {
         id: '1',
         language: 'en',
         kind: 'main',
         label: 'English',
-        _enabled: false,
-      }),
+        enabled: false,
+      },
       enumerable: true,
     },
     length: { value: 2 },
@@ -248,10 +235,18 @@ describe('HTML5TVsPlayback', function() {
       })
     })
 
-    test('returns null if audioTracks property doesn\'t exist on media element', () => {
+    test('does not return anything if no audio track is enabled', () => {
+      Object.values(this.playback.el.audioTracks).forEach(t => {
+        t.enabled = false
+      })
+
+      expect(this.playback.currentAudioTrack).toBeFalsy()
+    })
+
+    test('does not return anything if audioTracks property doesn\'t exist on media element', () => {
       delete window.HTMLMediaElement.prototype.audioTracks
 
-      expect(this.playback.currentAudioTrack).toBeNull()
+      expect(this.playback.currentAudioTrack).toBeFalsy()
     })
   })
 


### PR DESCRIPTION
This PR fixes two issues found while testing a multi audio-track HLS stream on the latest version of Safari (v15).

1) If a call to `currentAudioTrack` is made early at the beginning of playback no audio track in the `HTMLMediaElement` has the `enabled` flag as `true` and thus a `TypeError` was being thrown.

2) When an audio track `enabled` flag is turned on, all others should be turned off so that only a single audio track is used at a time. This behaviour, however, was not happening.

