### PR TITLE
Fix – Video Element's Height isn't being properly set

### DIFF
--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -29,7 +29,7 @@ export default class HTML5TVsPlayback extends Playback {
 
   get tagName() { return 'video' }
 
-  get attributes() { return { width: '100%' } }
+  get attributes() { return { width: '100%', height: '100%' } }
 
   get mediaType() { return this.el.duration === Infinity ? Playback.LIVE : Playback.VOD }
 

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -131,6 +131,10 @@ describe('HTML5TVsPlayback', function() {
     expect(`${this.playback.el.width}%`).toEqual(this.playback.attributes.width)
   })
 
+  test('attributes getter returns the height attribute that will be added on the plugin DOM element', () => {
+    expect(`${this.playback.el.height}%`).toEqual(this.playback.attributes.height)
+  })
+
   describe('mediaType getter', () => {
     test('returns Playback.LIVE if video.duration property is Infinity', () => {
       this.playback.el = { duration: Infinity }


### PR DESCRIPTION
This PR fixes an issue that was found while using the playback on a WebOS 4 SmartTV.

The `<video>` element's `height` property wasn't being properly set to its correct display (`100%`). The bug ended up cutting the video's viewable region.

## Before this PR

![image](https://user-images.githubusercontent.com/40682476/150022997-bd674b80-d4cc-4ef8-8a9c-70440e4421cd.png)

![IMG_20220118_184137](https://user-images.githubusercontent.com/40682476/150023224-5efb9d9d-ae98-487e-aaa9-d64569e321c6.jpg)

