### PR TITLE
Feature: Improve the playback with get and set methods to use and change some properties

### DIFF
--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -107,6 +107,7 @@ export default class HTML5TVsPlayback extends Playback {
   constructor(options, i18n, playerError) {
     super(options, i18n, playerError)
     this._onAudioTracksUpdated = this._onAudioTracksUpdated.bind(this)
+    this.playbackType = this.mediaType
 
     this._drmConfigured = false
     this._isReady = false
@@ -402,5 +403,9 @@ export default class HTML5TVsPlayback extends Playback {
    * This method currently exists for backward compatibility reasons.
    * Use the mediaType getter instead of it.
    */
-  getPlaybackType() { return this.mediaType }
+  getPlaybackType() { return this.playbackType }
+
+  setPlaybackType(type) { this.playbackType = type }
+
+  getSourceMedia() { return this._src }
 }

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -1195,7 +1195,16 @@ describe('HTML5TVsPlayback', function() {
     expect(this.playback.isPlaying()).toEqual(this.playback.playing)
   })
 
-  test('getPlaybackType method returns mediaType getter', () => {
+  test('getPlaybackType method returns playbackType getter', () => {
     expect(this.playback.getPlaybackType()).toEqual(this.playback.mediaType)
+  })
+
+  test('setPlaybackType method updates playbackType with new value', () => {
+    this.playback.setPlaybackType('new value')
+    expect(this.playback.getPlaybackType()).toEqual('new value')
+  })
+
+  test('getSourceMedia method returns source media getter', () => {
+    expect(this.playback.getSourceMedia()).toBe(this.playback._src)
   })
 })


### PR DESCRIPTION
## Summary 

This MR update the playback HTML with get and setters to use and change some private properties.

## Changes
- `html5_playback.js`: add get to source media value and set to change the playback type
- `html5_playback.test.js`:  add unit tests

## How to test