### PR TITLE
Feature: Improve the playback with get and set methods to use and change some properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ Group all DRM-related config. The currently available configs are:
 | `playback.minimumDvrSizeConfig` | Returns `options.playback.minimumDvrSize` if is configured and is a valid value. | `{Number}` |
 | `playback.dvrSize` | Returns `playback.minimumDvrSizeConfig` if is a valid value or one default value. (Currently, is 60 seconds) | `{Number}` |
 | `playback.dvrEnabled` | Indicates whether the live media is on DVR state. | `{Boolean}` |
+| `playback.playbackType` | Returns if the type of media when this property was not change the value is `live` or `vod`. | `{String}` |
+| `playback.sourceMedia` | Returns a media url in use. | `{String}` |
+
+| setter | description | parameter |
+|--------|-------------|----------|
+| `playback.playbackType` | Set the new value of playback.playbackType property. | `{String}` |
 
 ## Types
 #### `AudioTrack`

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -104,9 +104,22 @@ export default class HTML5TVsPlayback extends Playback {
     }
   }
 
+  get playbackType() {
+    return this._playbackType
+  }
+
+  set playbackType(newPlaybackType) {
+    this._playbackType = newPlaybackType
+  }
+
+  get sourceMedia() {
+    return this._src
+  }
+
   constructor(options, i18n, playerError) {
     super(options, i18n, playerError)
     this._onAudioTracksUpdated = this._onAudioTracksUpdated.bind(this)
+    this._playbackType = this.mediaType
 
     this._drmConfigured = false
     this._isReady = false

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -198,6 +198,22 @@ describe('HTML5TVsPlayback', function() {
     expect(this.playback.buffering).toEqual(this.playback._isBuffering)
   })
 
+  test('playbackType getter returns mediaType property when is not changed', () => {
+    this.playback.el = { duration: 0 }
+
+    expect(this.playback.playbackType).toEqual(this.playback.mediaType)
+  })
+
+  test('playbackType setter updates playbackType with new value', () => {
+    this.playback.playbackType = 'new value'
+
+    expect(this.playback.playbackType).toEqual('new value')
+  })
+
+  test('sourceMedia getter returns returns src property', () => {
+    expect(this.playback.sourceMedia).toBe(this.playback._src)
+  })
+
   test('adds event listeners to the audioTrack object of the media element', () => {
     expect(this.playback.el.audioTracks.addEventListener).toHaveBeenCalledWith('addtrack', this.playback._onAudioTracksUpdated)
     expect(this.playback.el.audioTracks.addEventListener).toHaveBeenCalledWith('removetrack', this.playback._onAudioTracksUpdated)


### PR DESCRIPTION
## Summary 

This MR update the playback HTML with getters and setters to use and change some private properties.

## Changes
- `html5_playback.js`: add get to source media value and set to change the playback type
- `html5_playback.test.js`:  add unit tests

## How to test
- Play any supported source;
- The `sourceMedia` getter should return the url media in use;
- The `playbackType` getter should return the same value of `mediaType`;
- Set other value to `playbackType` the `playbackType` property was changed;