### PR TITLE
Refactor: separates DRM config from setup source

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "test": "jest --coverage --silent",
+    "test:watch": "jest ./test --watch",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "test:coverage": "open coverage/lcov-report/index.html"
   },

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -150,7 +150,10 @@ export default class HTML5TVsPlayback extends Playback {
     this.$sourceElement.type = MIME_TYPES_BY_EXTENSION[getExtension(sourceURL)]
     this.$sourceElement.src = sourceURL
     this._src = this.$sourceElement.src
+    this._appendSourceElement()
+  }
 
+  _appendSourceElement() {
     this.config && this.config.drm && !this._drmConfigured
       ? DRMHandler.sendLicenseRequest.call(this, this.config.drm, this._onDrmConfigured, this._onDrmError)
       : this.el.appendChild(this.$sourceElement)
@@ -158,7 +161,7 @@ export default class HTML5TVsPlayback extends Playback {
 
   _onDrmConfigured() {
     this._drmConfigured = true
-    this.el.appendChild(this.$sourceElement)
+    this._appendSourceElement()
   }
 
   _onDrmCleared() {

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -1149,10 +1149,9 @@ describe('HTML5TVsPlayback', function() {
       expect(DRMHandler.clearLicenseRequest).toHaveBeenCalledWith(this.playback._onDrmCleared, this.playback._onDrmError)
     })
 
-    test('removes src attribute from the $sourceElement', () => {
+    test('sets $sourceElement to null', () => {
       this.playback._wipeUpMedia()
-
-      expect(this.playback.$sourceElement.src).toEqual('')
+      expect(this.playback.$sourceElement).toBe(null)
     })
 
     test('removes $sourceElement the DOM', () => {


### PR DESCRIPTION
Separates DRM config from setup source method.