### PR TITLE
HTML5 Playback - Improvements and fixes

### DIFF
--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -405,8 +405,8 @@ export default class HTML5TVsPlayback extends Playback {
   _signalizeReadyState(backOff = 100) {
     if (!this.isReady) return setTimeout(() => { this._signalizeReadyState(backOff * 2) }, backOff)
 
-    this.trigger(Events.PLAYBACK_READY, this.name)
     this._isReady = true
+    this.trigger(Events.PLAYBACK_READY, this.name)
   }
 
   /**

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -304,8 +304,8 @@ export default class HTML5TVsPlayback extends Playback {
 
   _onEnded(e) {
     Log.info(this.name, 'The HTMLMediaElement ended event is triggered: ', e)
-    this.trigger(Events.PLAYBACK_ENDED, this.name)
     this._wipeUpMedia()
+    this.trigger(Events.PLAYBACK_ENDED, this.name)
   }
 
   _onError(e) {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -33,7 +33,7 @@ export default class HTML5TVsPlayback extends Playback {
 
   get mediaType() { return this.el.duration === Infinity ? Playback.LIVE : Playback.VOD }
 
-  get isReady() { return this.el.readyState >= READY_STATE_STAGES.HAVE_CURRENT_DATA }
+  get isReady() { return this.el.readyState >= READY_STATE_STAGES.HAVE_FUTURE_DATA }
 
   get playing() { return !this.el.paused && !this.el.ended }
 
@@ -210,6 +210,7 @@ export default class HTML5TVsPlayback extends Playback {
 
   _onCanPlay(e) {
     Log.info(this.name, 'The HTMLMediaElement canplay event is triggered: ', e)
+    !this._isReady && this._signalizeReadyState()
     if (this._isBuffering) {
       this._isBuffering = false
       this.trigger(Events.PLAYBACK_BUFFERFULL, this.name)
@@ -231,7 +232,6 @@ export default class HTML5TVsPlayback extends Playback {
 
   _onLoadedData(e) {
     Log.info(this.name, 'The HTMLMediaElement loadeddata event is triggered: ', e)
-    !this._isReady && this._signalizeReadyState()
   }
 
   _onWaiting(e) {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -311,18 +311,15 @@ export default class HTML5TVsPlayback extends Playback {
   _onError(e) {
     Log.warn(this.name, 'The HTMLMediaElement error event is triggered: ', e)
     const { code, message } = this.$sourceElement?.error || this.el.error || UNKNOWN_ERROR
-    const isUnknownError = code === UNKNOWN_ERROR.code
 
     const formattedError = this.createError({
       code,
       description: message,
       raw: this.el.error,
-      level: isUnknownError ? PlayerError.Levels.WARN : PlayerError.Levels.FATAL,
+      level: PlayerError.Levels.FATAL,
     })
 
-    isUnknownError
-      ? Log.warn(this.name, 'HTML5 unknown error: ', formattedError)
-      : this.trigger(Events.PLAYBACK_ERROR, formattedError)
+    this.trigger(Events.PLAYBACK_ERROR, formattedError)
   }
 
   load(sourceURL) {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -20,7 +20,7 @@ export default class HTML5TVsPlayback extends Playback {
     const sourceExtension = getExtension(resourceUrl)
     const isSourceExtensionSupported = MIME_TYPES_BY_EXTENSION[sourceExtension]
 
-    return isSupportedMimetype || isSourceExtensionSupported
+    return !!(isSupportedMimetype || isSourceExtensionSupported)
   }
 
   get name() { return 'html5_tvs_playback' }

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -136,12 +136,12 @@ describe('HTML5TVsPlayback', function() {
     })
   })
 
-  test('isReady getter returns the check if video.readyState is greater than or equal HAVE_CURRENT_DATA value', () => {
+  test('isReady getter returns the check if video.readyState is greater than or equal HAVE_FUTURE_DATA value', () => {
     jest.spyOn(this.playback.el, 'readyState', 'get').mockReturnValueOnce(READY_STATE_STAGES.HAVE_NOTHING)
 
     expect(this.playback.isReady).toBeFalsy()
 
-    jest.spyOn(this.playback.el, 'readyState', 'get').mockReturnValueOnce(READY_STATE_STAGES.HAVE_CURRENT_DATA)
+    jest.spyOn(this.playback.el, 'readyState', 'get').mockReturnValueOnce(READY_STATE_STAGES.HAVE_FUTURE_DATA)
 
     expect(this.playback.isReady).toBeTruthy()
   })
@@ -820,13 +820,13 @@ describe('HTML5TVsPlayback', function() {
     })
   })
 
-  describe('_onLoadedData callback', () => {
+  describe('_onCanPlay callback', () => {
     test('calls _signalizeReadyState method if _isReady flag has a falsy value', () => {
       jest.spyOn(this.playback, '_signalizeReadyState')
       this.playback._isReady = true
-      this.playback._onLoadedData()
+      this.playback._onCanPlay()
       this.playback._isReady = false
-      this.playback._onLoadedData()
+      this.playback._onCanPlay()
 
       expect(this.playback._signalizeReadyState).toHaveBeenCalledTimes(1)
     })

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -918,6 +918,15 @@ describe('HTML5TVsPlayback', function() {
       expect(cb).toHaveBeenCalledTimes(1)
     })
 
+    test('calls _wipeUpMedia method before notifying PLAYBACK_ENDED event', done => {
+      jest.spyOn(this.playback, '_wipeUpMedia')
+      this.playback.listenToOnce(this.playback, Events.PLAYBACK_ENDED, () => {
+        expect(this.playback._wipeUpMedia).toHaveBeenCalledTimes(1)
+        done()
+      })
+      this.playback._onEnded()
+    })
+
     test('calls _wipeUpMedia method', () => {
       jest.spyOn(this.playback, '_wipeUpMedia')
       this.playback._onEnded()

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -936,25 +936,6 @@ describe('HTML5TVsPlayback', function() {
   })
 
   describe('_onError callback', () => {
-    test('logs warn message if is an unknown error', () => {
-      this.playback._onError()
-
-      expect(console.log).toHaveBeenNthCalledWith(
-        3,
-        LOG_WARN_HEAD_MESSAGE,
-        LOG_WARN_STYLE,
-        'HTML5 unknown error: ',
-        {
-          code: 'html5_tvs_playback:unknown',
-          description: 'unknown',
-          level: 'WARN',
-          origin: 'html5_tvs_playback',
-          raw: undefined,
-          scope: 'playback',
-        },
-      )
-    })
-
     test('triggers PLAYBACK_ERROR event with formatted error object', () => {
       const cb = jest.fn()
 

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -606,8 +606,22 @@ describe('HTML5TVsPlayback', function() {
 
       expect(console.log).toHaveBeenNthCalledWith(
         1,
-        LOG_INFO_HEAD_MESSAGE,
-        LOG_INFO_STYLE,
+        LOG_WARN_HEAD_MESSAGE,
+        LOG_WARN_STYLE,
+        'The HTMLMediaElement error event is triggered: ',
+        errorEvent,
+      )
+    })
+
+    test('maps _onError method as error event callback on source element', () => {
+      this.playback._setupSource(URL_VIDEO_MP4_EXAMPLE)
+      const errorEvent = new Event('error')
+      this.playback.$sourceElement.dispatchEvent(errorEvent)
+
+      expect(console.log).toHaveBeenNthCalledWith(
+        1,
+        LOG_WARN_HEAD_MESSAGE,
+        LOG_WARN_STYLE,
         'The HTMLMediaElement error event is triggered: ',
         errorEvent,
       )

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -88,15 +88,15 @@ describe('HTML5TVsPlayback', function() {
 
   describe('canPlay static method', () => {
     test('checks if one video URL has supported format', () => {
-      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_MP4_EXAMPLE)).toBeTruthy()
-      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_M3U8_EXAMPLE)).toBeTruthy()
-      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_UNSUPPORTED_FORMAT_EXAMPLE)).toBeFalsy()
+      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_MP4_EXAMPLE)).toBe(true)
+      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_M3U8_EXAMPLE)).toBe(true)
+      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_UNSUPPORTED_FORMAT_EXAMPLE)).toBe(false)
     })
 
     test('checks if one video is supported via mime type', () => {
-      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_EXAMPLE, 'video/mp4')).toBeTruthy()
-      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_EXAMPLE, 'application/vnd.apple.mpegurl')).toBeTruthy()
-      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_EXAMPLE, 'mock/xpto')).toBeFalsy()
+      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_EXAMPLE, 'video/mp4')).toBe(true)
+      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_EXAMPLE, 'application/vnd.apple.mpegurl')).toBe(true)
+      expect(HTML5TVsPlayback.canPlay(URL_VIDEO_EXAMPLE, 'mock/xpto')).toBe(false)
     })
   })
 

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -1203,6 +1203,17 @@ describe('HTML5TVsPlayback', function() {
       expect(this.playback._signalizeReadyState).toHaveBeenCalledTimes(5)
     })
 
+    test('sets _isReady flag with true value before triggering PLAYBACK_READY', done => {
+      jest.spyOn(this.playback, 'isReady', 'get').mockReturnValueOnce(true)
+      this.playback._isReady = false
+      this.playback.listenToOnce(this.playback, Events.PLAYBACK_READY, () => {
+        expect(this.playback._isReady).toBeTruthy()
+        done()
+      })
+
+      this.playback._signalizeReadyState()
+    })
+
     test('sets _isReady flag with true value', () => {
       jest.spyOn(this.playback, 'isReady', 'get').mockReturnValueOnce(true)
       this.playback._isReady = false


### PR DESCRIPTION
This MR implements the following improvements/fixes:

- update `canPlay` to return a `boolean` value
- add error listener to `source` tag to capture playback errors and set all errors as `FATAL`
- notify events (PLAYBACK_READY and PLAYBACK_ENDED) after the internal playback operations
- Update `isReady` only when the playback can start to play prevents stalls when trying to play: `canPlay` event / `HAVE_FUTURE_DATA` readyState
![Screenshot 2023-07-20 at 11 44 05](https://github.com/clappr/clappr-html5-tvs-playback/assets/14154066/64b083a9-5fe8-41a0-9d9d-6bf6c6555700)
