### PR TITLE
HTML5 Playback - Improve playback cleaning

### DIFF
--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -378,6 +378,9 @@ export default class HTML5TVsPlayback extends Playback {
     this._isDestroyed = true
     super.destroy()
     this._wipeUpMedia()
+    const { audioTracks } = this.el
+    audioTracks?.removeEventListener('addtrack', this._onAudioTracksUpdated)
+    audioTracks?.removeEventListener('removetrack', this._onAudioTracksUpdated)
     this._src = null
   }
 

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -156,9 +156,11 @@ export default class HTML5TVsPlayback extends Playback {
   }
 
   _appendSourceElement() {
-    this.config && this.config.drm && !this._drmConfigured
-      ? DRMHandler.sendLicenseRequest.call(this, this.config.drm, this._onDrmConfigured, this._onDrmError)
-      : this.el.appendChild(this.$sourceElement)
+    const shouldConfigureDRM = this.config && this.config.drm && !this._drmConfigured
+    if (shouldConfigureDRM) return DRMHandler.sendLicenseRequest.call(this, this.config.drm, this._onDrmConfigured, this._onDrmError)
+
+    this.el.appendChild(this.$sourceElement)
+    this.el.load()
   }
 
   _onDrmConfigured() {

--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -384,11 +384,11 @@ export default class HTML5TVsPlayback extends Playback {
     this._drmConfigured && DRMHandler.clearLicenseRequest.call(this, this._onDrmCleared, this._onDrmError)
     if (this.$sourceElement) {
       this.$sourceElement.removeEventListener('error', this._sourceElementErrorHandler)
-      this.$sourceElement.removeAttribute('src') // The src attribute will be added again in play().
+      this.$sourceElement.src = '' // The src attribute will be added again in play().
+      this.el.load() // Loads with no src attribute to stop the loading of the previous source and avoid leaks.
       this.$sourceElement.parentNode && this.$sourceElement.parentNode.removeChild(this.$sourceElement)
       this.$sourceElement = null
     }
-    this.el.load() // Loads with no src attribute to stop the loading of the previous source and avoid leaks.
   }
 
   /**

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -717,6 +717,13 @@ describe('HTML5TVsPlayback', function() {
 
       expect(this.playback.el.firstChild).toEqual(this.playback.$sourceElement)
     })
+
+    test('calls load on playback.el after setting up source', () => {
+      jest.spyOn(this.playback.el, 'load')
+      this.playback._setupSource(URL_VIDEO_MP4_EXAMPLE)
+
+      expect(this.playback.el.load).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('_onDrmConfigured callback', () => {

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -996,13 +996,15 @@ describe('HTML5TVsPlayback', function() {
     })
 
     test('logs video.play promise problems', () => {
-      window.HTMLMediaElement.prototype.play = () => new Promise(() => { throw new Error('Uh-oh!') })
+      const error = new Error('Uh-oh!')
+      window.HTMLMediaElement.prototype.play = () => new Promise(() => { throw error })
 
       this.playback.play()
       this.playback.el.play().catch(() => expect(console.log).toHaveBeenCalledWith(
         LOG_WARN_HEAD_MESSAGE,
         LOG_WARN_STYLE,
-        'The play promise throws one error: Uh-oh!',
+        'The play promise throws one error: ',
+        error,
       ))
     })
   })

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -34,6 +34,7 @@ const createAudioTrackListStub = () => {
 
   Object.defineProperties(tracks, {
     addEventListener: { value: jest.fn() },
+    removeEventListener: { value: jest.fn() },
     getTrackById: { value: id => tracks[id] },
     0: {
       value: {
@@ -1138,6 +1139,15 @@ describe('HTML5TVsPlayback', function() {
       this.playback.destroy()
 
       expect(this.playback._src).toBeNull()
+    })
+
+    test('removes event listeners from audio tracks', () => {
+      this.playback._src = URL_VIDEO_MP4_EXAMPLE
+      this.playback.destroy()
+
+      expect(this.playback.el.audioTracks.removeEventListener).toHaveBeenCalledTimes(2)
+      expect(this.playback.el.audioTracks.removeEventListener).toHaveBeenCalledWith('addtrack', this.playback._onAudioTracksUpdated)
+      expect(this.playback.el.audioTracks.removeEventListener).toHaveBeenCalledWith('removetrack', this.playback._onAudioTracksUpdated)
     })
   })
 


### PR DESCRIPTION
This MR implements the following improvements/fixes:

- [Updates the wipe of video tag to follow the recommendation for releasing memory](https://github.com/clappr/clappr-html5-tvs-playback/pull/25/commits/4c21d78295828006f9572ca3b6a2b7d3dc1febc7)
- [Remove audio track listeners on destroy to prevent memory leak](https://github.com/clappr/clappr-html5-tvs-playback/pull/25/commits/d37a66be392e1bd6188cd559b0563d88c3d845d4)
- [Calls `load` after updating source to fetch data from new source](https://github.com/clappr/clappr-html5-tvs-playback/pull/25/commits/e1641647d301b8d0c1d92f89475c865e95c2f4ad)


Besides that, a [fix for a broken test](https://github.com/clappr/clappr-html5-tvs-playback/pull/25/commits/1795331e83afab45d06574d35e76c7625c00c8ac) was also added.
