### PR TITLE
DRM - Add option to disable DRM client Setup

### DIFF
--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -156,7 +156,7 @@ export default class HTML5TVsPlayback extends Playback {
   }
 
   _appendSourceElement() {
-    const shouldConfigureDRM = this.config && this.config.drm && !this._drmConfigured
+    const shouldConfigureDRM = !this.config?.disableDRMSetup && this.config?.drm && !this._drmConfigured
     if (shouldConfigureDRM) return DRMHandler.sendLicenseRequest.call(this, this.config.drm, this._onDrmConfigured, this._onDrmError)
 
     this.el.appendChild(this.$sourceElement)

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -713,6 +713,16 @@ describe('HTML5TVsPlayback', function() {
       )
     })
 
+    test('does not setup license server if config.disableDRMSetup is set', () => {
+      const { core, container } = setupTest({ src: URL_VIDEO_MP4_EXAMPLE, html5TvsPlayback: { disableDRMSetup: true, drm: { licenseServerURL: 'http://fake-domain.com/license_server/playready' } } })
+      core.activeContainer = container
+
+      jest.spyOn(DRMHandler, 'sendLicenseRequest')
+      container.playback._setupSource(URL_VIDEO_MP4_EXAMPLE)
+
+      expect(DRMHandler.sendLicenseRequest).not.toHaveBeenCalled()
+    })
+
     test('appends $sourceElement into the playback.el if no one license server URL is configured or _drmConfigured flag is true', () => {
       this.playback._setupSource(URL_VIDEO_MP4_EXAMPLE)
 


### PR DESCRIPTION
Some platforms do not support the DRM Client Setup. To prevent errors, the setup needs to be disabled on these platforms in favor of the post-delivery method for setting up DRM handled by the platform.