### PR TITLE
Fix exceptions due to invalid time range access and raw code error value

### DIFF
--- a/src/html5_playback.js
+++ b/src/html5_playback.js
@@ -312,12 +312,13 @@ export default class HTML5TVsPlayback extends Playback {
 
   _onError(e) {
     Log.warn(this.name, 'The HTMLMediaElement error event is triggered: ', e)
-    const { code, message } = this.$sourceElement?.error || this.el.error || UNKNOWN_ERROR
+    const rawError = this.$sourceElement?.error || this.el.error || UNKNOWN_ERROR
+    const { code, message } = rawError
 
     const formattedError = this.createError({
       code,
       description: message,
-      raw: this.el.error,
+      raw: rawError,
       level: PlayerError.Levels.FATAL,
     })
 

--- a/src/html5_playback.test.js
+++ b/src/html5_playback.test.js
@@ -189,6 +189,24 @@ describe('HTML5TVsPlayback', function() {
 
       expect(this.playback.duration).toEqual(1000)
     })
+
+    test('handle exception if TimeRange access throws error', () => {
+      const startTimeChunks = [0, 11, 101]
+      const endTimeChunks = [10, 100, 1000]
+
+      jest.spyOn(this.playback, 'isLive', 'get').mockImplementation(() => true)
+
+      this.playback.el = {
+        seekable: {
+          start: index => startTimeChunks[index],
+          end: index => { throw new Error('IndexSizeError') },
+          length: 3,
+        },
+        duration: Infinity
+      }
+
+      expect(this.playback.duration).toEqual(Infinity)
+    })
   })
 
   test('ended getter returns video.ended property', () => {


### PR DESCRIPTION
The access to TimeRanges `start` and `end` methods can throw exceptions as detailed on https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges/start#exceptions and https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges/end#exceptions.

This MR adds a handler for this case and fixes the value of the `raw` property from the error object, which is not always `this.el.error`.